### PR TITLE
fix package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "zendframework/zendservice-twitter",
+    "name": "zendframework/zend-service-twitter",
     "description": "OOP wrapper for the Twitter web service",
     "type": "library",
     "keywords": [


### PR DESCRIPTION
in conformity with http://packages.zendframework.com/packages.json

and who can fixed packages names on http://packages.zendframework.com/#composer?

> zendframework/zend-service/twitter

and etc zend-service packages
