### PR TITLE
update zendservice composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "zendframework/zendservice-twitter",
+    "name": "chrisweb/zendservice-twitter",
     "description": "OOP wrapper for the Twitter web service",
     "type": "library",
     "keywords": [


### PR DESCRIPTION
I did some namespace fixes in the zendservice twitter files and afterwards tried to run the tests. The tests required me to run composer first, but composer failed, telling me that zendservice-twitter required zendframework 2.0.0beta5, but i use zendframework2.0.0RC5.

I saw that other composer.json files used self.version as version information. So i made the change in zendservice-twitter. This change should be made for each zendservice package, but i wonder why the composer.json file is in the root of zendservice and not the root of the twitter service. Do you want zendservice to be a single package with all the services in it, will each service be a serperated package. Not every service has the same dependencies, for example zendservice-twitter has a depency on zendoauth as well as zendrest. So wouldnt it be better to put a composer file in /zendservice/library/ZendService/Twitter instead of /zendservice?
