### PR TITLE
Fix tests error when the big int was converted to float

### DIFF
--- a/tests/ZendService/Twitter/TwitterTest.php
+++ b/tests/ZendService/Twitter/TwitterTest.php
@@ -362,7 +362,7 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
         $twitter->setHttpClient($this->stubTwitter(
             'statuses/show/307529814640840705.json', Http\Request::METHOD_GET, 'statuses.show.json'
         ));
-        $response = $twitter->statuses->show(307529814640840705);
+        $response = $twitter->statuses->show('307529814640840705');
         $this->assertTrue($response instanceof TwitterResponse);
     }
 


### PR DESCRIPTION
```
1) ZendTest\Twitter\TwitterTest::testShowStatusReturnsResponse
Expectation failed for method name is equal to <string:setUri> when invoked 1 time(s)
Parameter 0 for invocation Zend\Http\Client::setUri('https://api.twitter.com/1.1/s...7.json') does not match expected value.
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'https://api.twitter.com/1.1/statuses/show/307529814640840705.json'
+'https://api.twitter.com/1.1/statuses/show/3.0752981464084E+17.json'

C:\xampp\htdocs\ZendService_Twitter\library\ZendService\Twitter\Twitter.php:1171
C:\xampp\htdocs\ZendService_Twitter\library\ZendService\Twitter\Twitter.php:1190
C:\xampp\htdocs\ZendService_Twitter\library\ZendService\Twitter\Twitter.php:925
C:\xampp\htdocs\ZendService_Twitter\library\ZendService\Twitter\Twitter.php:237
C:\xampp\htdocs\ZendService_Twitter\tests\ZendService\Twitter\TwitterTest.php:365
C:\xampp\htdocs\ZendService_Twitter\tests\ZendService\Twitter\TwitterTest.php:365
```
