### PR TITLE
#15 remove int casting, because using regex check as int.

### DIFF
--- a/library/ZendService/Twitter/Twitter.php
+++ b/library/ZendService/Twitter/Twitter.php
@@ -1135,7 +1135,7 @@ class Twitter
     protected function validInteger($int)
     {
         if (preg_match("/^(\d+)$/", $int)) {
-            return (int)$int;
+            return $int;
         }
         return 0;
     }


### PR DESCRIPTION
see #15
