### PR TITLE
+Tests to check if adapter passed in http_client_options gets correctly initialized

### DIFF
--- a/tests/ZendService/Twitter/TwitterTest.php
+++ b/tests/ZendService/Twitter/TwitterTest.php
@@ -13,6 +13,7 @@ namespace ZendTest\Twitter;
 use Zend\Http;
 use ZendService\Twitter;
 use ZendService\Twitter\Response as TwitterResponse;
+use Zend\Http\Client\Adapter\Curl as CurlAdapter;
 
 /**
  * @category   Zend
@@ -580,56 +581,54 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($response instanceof TwitterResponse);
     }
 
-    public function testAdapterAlwaysReachableIfSpecified()
-    {
-        $adapter = new \Zend\Http\Client\Adapter\Curl();
+    public function providerAdapterAlwaysReachableIfSpecifiedConfiguration() {
+        $adapter = new CurlAdapter();
 
-        $config = array(
-            'http_client_options' => array(
-                'adapter' => $adapter,
+        return array(
+            array(
+                array(
+                    'http_client_options' => array(
+                        'adapter' => $adapter,
+                    ),
+                ),
+                $adapter
+            ),
+            array(
+                array(
+                    'access_token' => array(
+                        'token'  => 'some_token',
+                        'secret' => 'some_secret',
+                    ),
+                    'http_client_options' => array(
+                        'adapter' => $adapter,
+                    ),
+                ),
+                $adapter
+            ),
+            array(
+                array(
+                    'access_token' => array(
+                        'token'  => 'some_token',
+                        'secret' => 'some_secret',
+                    ),
+                    'oauth_options' => array(
+                        'consumerKey' => 'some_consumer_key',
+                        'consumerSecret' => 'some_consumer_secret',
+                    ),
+                    'http_client_options' => array(
+                        'adapter' => $adapter,
+                    ),
+                ),
+                $adapter
             ),
         );
-
-        $twitter = new \ZendService\Twitter\Twitter($config);
-        $this->assertSame($adapter, $twitter->getHttpClient()->getAdapter());
     }
 
-    public function testAdapterAlwaysReachableIfSpecifiedWithAccessToken()
+    /**
+     * @dataProvider providerAdapterAlwaysReachableIfSpecifiedConfiguration
+      */
+    public function testAdapterAlwaysReachableIfSpecified($config, $adapter)
     {
-        $adapter = new \Zend\Http\Client\Adapter\Curl();
-
-        $config = array(
-            'access_token' => array(
-                'token'  => 'some_token',
-                'secret' => 'some_secret',
-            ),
-            'http_client_options' => array(
-                'adapter' => $adapter,
-            ),
-        );
-
-        $twitter = new \ZendService\Twitter\Twitter($config);
-        $this->assertSame($adapter, $twitter->getHttpClient()->getAdapter());
-    }
-
-    public function testAdapterAlwaysReachableIfSpecifiedWithAccessTokenAndOAuthOptions()
-    {
-        $adapter = new \Zend\Http\Client\Adapter\Curl();
-
-        $config = array(
-            'access_token' => array(
-                'token'  => 'some_token',
-                'secret' => 'some_secret',
-            ),
-            'oauth_options' => array(
-                'consumerKey' => 'some_consumer_key',
-                'consumerSecret' => 'some_consumer_secret',
-            ),
-            'http_client_options' => array(
-                'adapter' => $adapter,
-            ),
-        );
-
         $twitter = new \ZendService\Twitter\Twitter($config);
         $this->assertSame($adapter, $twitter->getHttpClient()->getAdapter());
     }

--- a/tests/ZendService/Twitter/TwitterTest.php
+++ b/tests/ZendService/Twitter/TwitterTest.php
@@ -579,4 +579,58 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
         $response = $twitter->users->search('Zend');
         $this->assertTrue($response instanceof TwitterResponse);
     }
+
+    public function testAdapterAlwaysReachableIfSpecified()
+    {
+        $adapter = new \Zend\Http\Client\Adapter\Curl();
+
+        $config = array(
+            'http_client_options' => array(
+                'adapter' => $adapter,
+            ),
+        );
+
+        $twitter = new \ZendService\Twitter\Twitter($config);
+        $this->assertSame($adapter, $twitter->getHttpClient()->getAdapter());
+    }
+
+    public function testAdapterAlwaysReachableIfSpecifiedWithAccessToken()
+    {
+        $adapter = new \Zend\Http\Client\Adapter\Curl();
+
+        $config = array(
+            'access_token' => array(
+                'token'  => 'some_token',
+                'secret' => 'some_secret',
+            ),
+            'http_client_options' => array(
+                'adapter' => $adapter,
+            ),
+        );
+
+        $twitter = new \ZendService\Twitter\Twitter($config);
+        $this->assertSame($adapter, $twitter->getHttpClient()->getAdapter());
+    }
+
+    public function testAdapterAlwaysReachableIfSpecifiedWithAccessTokenAndOAuthOptions()
+    {
+        $adapter = new \Zend\Http\Client\Adapter\Curl();
+
+        $config = array(
+            'access_token' => array(
+                'token'  => 'some_token',
+                'secret' => 'some_secret',
+            ),
+            'oauth_options' => array(
+                'consumerKey' => 'some_consumer_key',
+                'consumerSecret' => 'some_consumer_secret',
+            ),
+            'http_client_options' => array(
+                'adapter' => $adapter,
+            ),
+        );
+
+        $twitter = new \ZendService\Twitter\Twitter($config);
+        $this->assertSame($adapter, $twitter->getHttpClient()->getAdapter());
+    }
 }


### PR DESCRIPTION
Hello, I hope these tests are useful. I've added three tests to check if the adapter passed in the http_client_options gets correctly initialized.

The first test `testAdapterAlwaysReachableIfSpecified` passes, but the other two don't. It seems there is some issue when passing `access_token`.

I got the problem while following the [documentation on Authentication](http://zf2.readthedocs.org/en/latest/modules/zendservice.twitter.html#authentication) where it says that this configuration can be used:

	$twitter = new ZendService\Twitter\Twitter(array(
	    'access_token' => array( // or use "accessToken" as the key; both work
	        'token' => 'your-access-token',
	        'secret' => 'your-access-token-secret',
	    ),
	    'oauth_options' => array( // or use "oauthOptions" as the key; both work
	        'consumerKey' => 'your-consumer-key',
	        'consumerSecret' => 'your-consumer-secret',
	    ),
	    'http_client_options' => array(
	        'adapter' => 'Zend_Http\Client\Adapter\Curl',
	    ),
	));
