### PR TITLE
Modernize component (somewhat)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,5 @@ nbproject
 .settings/
 tmp/
 .DS_Store
-composer.lock
 .*.sw*
 .*.un~

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,22 +14,13 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.5
+    - php: 5.6
       env:
         - DEPS=lowest
-    - php: 5.5
+    - php: 5.6
       env:
         - DEPS=locked
         - CHECK_CS=true
-    - php: 5.5
-      env:
-        - DEPS=latest
-    - php: 5.6
-      env:
-        - DEPS=lowest
-    - php: 5.6
-      env:
-        - DEPS=locked
     - php: 5.6
       env:
         - DEPS=latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,62 @@
+sudo: false
+
 language: php
 
-php:
-  - 5.3
-  - 5.4
-  - 5.5
+cache:
+  directories:
+    - $HOME/.composer/cache
+    - vendor
+
+env:
+  global:
+    - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.5
+      env:
+        - DEPS=lowest
+    - php: 5.5
+      env:
+        - DEPS=locked
+        - CHECK_CS=true
+    - php: 5.5
+      env:
+        - DEPS=latest
+    - php: 5.6
+      env:
+        - DEPS=lowest
+    - php: 5.6
+      env:
+        - DEPS=locked
+    - php: 5.6
+      env:
+        - DEPS=latest
+    - php: 7.0
+      env:
+        - DEPS=lowest
+    - php: 7.0
+      env:
+        - DEPS=locked
+    - php: 7.0
+      env:
+        - DEPS=latest
 
 before_install:
  - cp tests/TestConfiguration.php.travis tests/TestConfiguration.php
- - composer install --dev
- - wget http://cs.sensiolabs.org/get/php-cs-fixer.phar
+ - phpenv config-rm xdebug.ini
+ - travis_retry composer self-update
+
+install:
+  - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
+  - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
+  - travis_retry composer install $COMPOSER_ARGS
+  - composer show --installed
 
 script:
- - phpunit -c ./tests/
- - output=$(php php-cs-fixer.phar fix -v --dry-run --level=psr2 .); if [[ $output ]]; then while read -r line; do echo -e "\e[00;31m$line\e[00m"; done <<< "$output"; false; fi;
+ - vendor/bin/phpunit
+ - if [[ $CHECK_CS == 'true' ]]; then vendor/bin/phpcs ; fi
 
 notifications:
   irc: "irc.freenode.org#zftalk.dev"

--- a/composer.json
+++ b/composer.json
@@ -6,30 +6,24 @@
         "zf2",
         "twitter"
     ],
-    "homepage": "http://packages.zendframework.com/",
     "license": "BSD-3-Clause",
     "autoload": {
         "psr-0": {
             "ZendService\\Twitter\\": "library/"
         }
     },
-    "repositories": [
-        {
-            "type": "composer",
-            "url": "http://packages.zendframework.com/"
-        }
-    ],
     "require": {
-        "php": ">=5.3.3",
-        "zendframework/zend-feed": ">=2.0.0",
-        "zendframework/zend-http": ">=2.0.0",
-        "zendframework/zend-json": ">=2.0.0",
-        "zendframework/zend-stdlib": ">=2.0.0",
-        "zendframework/zend-uri": ">=2.0.0",
-        "zendframework/zendoauth": ">=2.0.0"
+        "php": "^5.5 || ^7.0",
+        "zendframework/zend-feed": "^2.7",
+        "zendframework/zend-http": "^2.5.4",
+        "zendframework/zend-json": "^2.6.1 || ^3.0",
+        "zendframework/zend-stdlib": "^2.7.7 || ^3.0.1",
+        "zendframework/zend-uri": "^2.5.2",
+        "zendframework/zendoauth": "^2.0.3"
     },
     "require-dev": {
-        "zendframework/zend-config": ">=2.0.0"
+        "squizlabs/php_codesniffer": "^2.6.2",
+        "phpunit/phpunit": "^4.8 || ^5.0"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     },
     "require": {
-        "php": "^5.5 || ^7.0",
+        "php": "^5.6 || ^7.0",
         "zendframework/zend-feed": "^2.7",
         "zendframework/zend-http": "^2.5.4",
         "zendframework/zend-json": "^2.6.1 || ^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "99369f084c065c8ab2fb7b1f5ddf8baf",
-    "content-hash": "693ca1a9a293d09033a66a2efa42aa12",
+    "hash": "3c6b883f32571eaba8e338ff0fa43442",
+    "content-hash": "56dea0d15bd10076815f41e266466629",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -2148,7 +2148,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.5 || ^7.0"
+        "php": "^5.6 || ^7.0"
     },
     "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,2154 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "99369f084c065c8ab2fb7b1f5ddf8baf",
+    "content-hash": "693ca1a9a293d09033a66a2efa42aa12",
+    "packages": [
+        {
+            "name": "container-interop/container-interop",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/container-interop/container-interop.git",
+                "reference": "fc08354828f8fd3245f77a66b9e23a6bca48297e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/fc08354828f8fd3245f77a66b9e23a6bca48297e",
+                "reference": "fc08354828f8fd3245f77a66b9e23a6bca48297e",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Container\\": "src/Interop/Container/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
+            "time": "2014-12-30 15:22:37"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "088c04e2f261c33bed6ca5245491cfca69195ccf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/088c04e2f261c33bed6ca5245491cfca69195ccf",
+                "reference": "088c04e2f261c33bed6ca5245491cfca69195ccf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/random.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "pseudorandom",
+                "random"
+            ],
+            "time": "2016-04-03 06:00:07"
+        },
+        {
+            "name": "zendframework/zend-config",
+            "version": "2.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-config.git",
+                "reference": "2920e877a9f6dca9fa8f6bd3b1ffc2e19bb1e30d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-config/zipball/2920e877a9f6dca9fa8f6bd3b1ffc2e19bb1e30d",
+                "reference": "2920e877a9f6dca9fa8f6bd3b1ffc2e19bb1e30d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0",
+                "zendframework/zend-filter": "^2.6",
+                "zendframework/zend-i18n": "^2.5",
+                "zendframework/zend-json": "^2.6.1",
+                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3"
+            },
+            "suggest": {
+                "zendframework/zend-filter": "Zend\\Filter component",
+                "zendframework/zend-i18n": "Zend\\I18n component",
+                "zendframework/zend-json": "Zend\\Json to use the Json reader or writer classes",
+                "zendframework/zend-servicemanager": "Zend\\ServiceManager for use with the Config Factory to retrieve reader and writer instances"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev",
+                    "dev-develop": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Config\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides a nested object property based user interface for accessing this configuration data within application code",
+            "homepage": "https://github.com/zendframework/zend-config",
+            "keywords": [
+                "config",
+                "zf2"
+            ],
+            "time": "2016-02-04 23:01:10"
+        },
+        {
+            "name": "zendframework/zend-crypt",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-crypt.git",
+                "reference": "ed348e3e87c945759d11edae5316125c3582bc72"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-crypt/zipball/ed348e3e87c945759d11edae5316125c3582bc72",
+                "reference": "ed348e3e87c945759d11edae5316125c3582bc72",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "~1.0",
+                "ext-mbstring": "*",
+                "php": "^5.6 || ^7.0",
+                "zendframework/zend-math": "^3.0",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8",
+                "squizlabs/php_codesniffer": "^2.3.1"
+            },
+            "suggest": {
+                "ext-openssl": "Required for most features of Zend\\Crypt"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev",
+                    "dev-develop": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Crypt\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-crypt",
+            "keywords": [
+                "crypt",
+                "zf2"
+            ],
+            "time": "2016-06-21 18:15:32"
+        },
+        {
+            "name": "zendframework/zend-escaper",
+            "version": "2.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-escaper.git",
+                "reference": "2dcd14b61a72d8b8e27d579c6344e12c26141d4e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-escaper/zipball/2dcd14b61a72d8b8e27d579c6344e12c26141d4e",
+                "reference": "2dcd14b61a72d8b8e27d579c6344e12c26141d4e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev",
+                    "dev-develop": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Escaper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-escaper",
+            "keywords": [
+                "escaper",
+                "zf2"
+            ],
+            "time": "2016-06-30 19:48:38"
+        },
+        {
+            "name": "zendframework/zend-feed",
+            "version": "2.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-feed.git",
+                "reference": "12b328d382aa5200f1de53d4147033b885776b67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-feed/zipball/12b328d382aa5200f1de53d4147033b885776b67",
+                "reference": "12b328d382aa5200f1de53d4147033b885776b67",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "zendframework/zend-escaper": "^2.5",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0",
+                "psr/http-message": "^1.0",
+                "zendframework/zend-cache": "^2.5",
+                "zendframework/zend-db": "^2.5",
+                "zendframework/zend-http": "^2.5",
+                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+                "zendframework/zend-validator": "^2.5"
+            },
+            "suggest": {
+                "psr/http-message": "PSR-7 ^1.0, if you wish to use Zend\\Feed\\Reader\\Http\\Psr7ResponseDecorator",
+                "zendframework/zend-cache": "Zend\\Cache component, for optionally caching feeds between requests",
+                "zendframework/zend-db": "Zend\\Db component, for use with PubSubHubbub",
+                "zendframework/zend-http": "Zend\\Http for PubSubHubbub, and optionally for use with Zend\\Feed\\Reader",
+                "zendframework/zend-servicemanager": "Zend\\ServiceManager component, for easily extending ExtensionManager implementations",
+                "zendframework/zend-validator": "Zend\\Validator component, for validating email addresses used in Atom feeds and entries ehen using the Writer subcomponent"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev",
+                    "dev-develop": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Feed\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides functionality for consuming RSS and Atom feeds",
+            "homepage": "https://github.com/zendframework/zend-feed",
+            "keywords": [
+                "feed",
+                "zf2"
+            ],
+            "time": "2016-02-11 18:54:29"
+        },
+        {
+            "name": "zendframework/zend-http",
+            "version": "2.5.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-http.git",
+                "reference": "7b920b4ec34b5ee58f76eb4e8c408b083121953c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-http/zipball/7b920b4ec34b5ee58f76eb4e8c408b083121953c",
+                "reference": "7b920b4ec34b5ee58f76eb4e8c408b083121953c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "zendframework/zend-loader": "^2.5",
+                "zendframework/zend-stdlib": "^2.5 || ^3.0",
+                "zendframework/zend-uri": "^2.5",
+                "zendframework/zend-validator": "^2.5"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "^4.0",
+                "zendframework/zend-config": "^2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev",
+                    "dev-develop": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Http\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides an easy interface for performing Hyper-Text Transfer Protocol (HTTP) requests",
+            "homepage": "https://github.com/zendframework/zend-http",
+            "keywords": [
+                "http",
+                "zf2"
+            ],
+            "time": "2016-02-04 20:36:48"
+        },
+        {
+            "name": "zendframework/zend-i18n",
+            "version": "2.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-i18n.git",
+                "reference": "b2db0d8246a865c659f93199f90f5fc2cd2f3cd8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-i18n/zipball/b2db0d8246a865c659f93199f90f5fc2cd2f3cd8",
+                "reference": "b2db0d8246a865c659f93199f90f5fc2cd2f3cd8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0",
+                "zendframework/zend-cache": "^2.6.1",
+                "zendframework/zend-config": "^2.6",
+                "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
+                "zendframework/zend-filter": "^2.6.1",
+                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+                "zendframework/zend-validator": "^2.6",
+                "zendframework/zend-view": "^2.6.3"
+            },
+            "suggest": {
+                "ext-intl": "Required for most features of Zend\\I18n; included in default builds of PHP",
+                "zendframework/zend-cache": "Zend\\Cache component",
+                "zendframework/zend-config": "Zend\\Config component",
+                "zendframework/zend-eventmanager": "You should install this package to use the events in the translator",
+                "zendframework/zend-filter": "You should install this package to use the provided filters",
+                "zendframework/zend-i18n-resources": "Translation resources",
+                "zendframework/zend-servicemanager": "Zend\\ServiceManager component",
+                "zendframework/zend-validator": "You should install this package to use the provided validators",
+                "zendframework/zend-view": "You should install this package to use the provided view helpers"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev",
+                    "dev-develop": "2.8-dev"
+                },
+                "zf": {
+                    "component": "Zend\\I18n",
+                    "config-provider": "Zend\\I18n\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\I18n\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-i18n",
+            "keywords": [
+                "i18n",
+                "zf2"
+            ],
+            "time": "2016-06-07 21:08:30"
+        },
+        {
+            "name": "zendframework/zend-json",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-json.git",
+                "reference": "f42a1588e75c2a3e338cd94c37906231e616daab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-json/zipball/f42a1588e75c2a3e338cd94c37906231e616daab",
+                "reference": "f42a1588e75c2a3e338cd94c37906231e616daab",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "^2.3",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+            },
+            "suggest": {
+                "zendframework/zend-json-server": "For implementing JSON-RPC servers",
+                "zendframework/zend-xml2json": "For converting XML documents to JSON"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev",
+                    "dev-develop": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Json\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides convenience methods for serializing native PHP to JSON and decoding JSON to native PHP",
+            "homepage": "https://github.com/zendframework/zend-json",
+            "keywords": [
+                "json",
+                "zf2"
+            ],
+            "time": "2016-04-01 02:34:00"
+        },
+        {
+            "name": "zendframework/zend-loader",
+            "version": "2.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-loader.git",
+                "reference": "c5fd2f071bde071f4363def7dea8dec7393e135c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-loader/zipball/c5fd2f071bde071f4363def7dea8dec7393e135c",
+                "reference": "c5fd2f071bde071f4363def7dea8dec7393e135c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.23"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev",
+                    "dev-develop": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Loader\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-loader",
+            "keywords": [
+                "loader",
+                "zf2"
+            ],
+            "time": "2015-06-03 14:05:47"
+        },
+        {
+            "name": "zendframework/zend-math",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-math.git",
+                "reference": "fda3b4e6c3bb15c35adc6db38b2eacabaa243e65"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-math/zipball/fda3b4e6c3bb15c35adc6db38b2eacabaa243e65",
+                "reference": "fda3b4e6c3bb15c35adc6db38b2eacabaa243e65",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "paragonie/random_compat": "^2.0.2",
+                "php": "^5.5 || ^7.0"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "ext-bcmath": "If using the bcmath functionality",
+                "ext-gmp": "If using the gmp functionality"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev",
+                    "dev-develop": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Math\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-math",
+            "keywords": [
+                "math",
+                "zf2"
+            ],
+            "time": "2016-04-28 17:37:42"
+        },
+        {
+            "name": "zendframework/zend-stdlib",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-stdlib.git",
+                "reference": "8bafa58574204bdff03c275d1d618aaa601588ae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/8bafa58574204bdff03c275d1d618aaa601588ae",
+                "reference": "8bafa58574204bdff03c275d1d618aaa601588ae",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1",
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev",
+                    "dev-develop": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Stdlib\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-stdlib",
+            "keywords": [
+                "stdlib",
+                "zf2"
+            ],
+            "time": "2016-04-12 21:19:36"
+        },
+        {
+            "name": "zendframework/zend-uri",
+            "version": "2.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-uri.git",
+                "reference": "0bf717a239432b1a1675ae314f7c4acd742749ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-uri/zipball/0bf717a239432b1a1675ae314f7c4acd742749ed",
+                "reference": "0bf717a239432b1a1675ae314f7c4acd742749ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "zendframework/zend-escaper": "^2.5",
+                "zendframework/zend-validator": "^2.5"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev",
+                    "dev-develop": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Uri\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "a component that aids in manipulating and validating » Uniform Resource Identifiers (URIs)",
+            "homepage": "https://github.com/zendframework/zend-uri",
+            "keywords": [
+                "uri",
+                "zf2"
+            ],
+            "time": "2016-02-17 22:38:51"
+        },
+        {
+            "name": "zendframework/zend-validator",
+            "version": "2.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-validator.git",
+                "reference": "8ec9f57a717dd37340308aa632f148a2c2be1cfc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-validator/zipball/8ec9f57a717dd37340308aa632f148a2c2be1cfc",
+                "reference": "8ec9f57a717dd37340308aa632f148a2c2be1cfc",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.1",
+                "php": "^5.5 || ^7.0",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "^4.0",
+                "zendframework/zend-cache": "^2.6.1",
+                "zendframework/zend-config": "^2.6",
+                "zendframework/zend-db": "^2.7",
+                "zendframework/zend-filter": "^2.6",
+                "zendframework/zend-http": "^2.5.4",
+                "zendframework/zend-i18n": "^2.6",
+                "zendframework/zend-math": "^2.6",
+                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+                "zendframework/zend-session": "^2.6.2",
+                "zendframework/zend-uri": "^2.5"
+            },
+            "suggest": {
+                "zendframework/zend-db": "Zend\\Db component",
+                "zendframework/zend-filter": "Zend\\Filter component, required by the Digits validator",
+                "zendframework/zend-i18n": "Zend\\I18n component to allow translation of validation error messages as well as to use the various Date validators",
+                "zendframework/zend-i18n-resources": "Translations of validator messages",
+                "zendframework/zend-math": "Zend\\Math component",
+                "zendframework/zend-servicemanager": "Zend\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
+                "zendframework/zend-session": "Zend\\Session component",
+                "zendframework/zend-uri": "Zend\\Uri component, required by the Uri and Sitemap\\Loc validators"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev",
+                    "dev-develop": "2.9-dev"
+                },
+                "zf": {
+                    "component": "Zend\\Validator",
+                    "config-provider": "Zend\\Validator\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Validator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides a set of commonly needed validators",
+            "homepage": "https://github.com/zendframework/zend-validator",
+            "keywords": [
+                "validator",
+                "zf2"
+            ],
+            "time": "2016-06-23 13:44:31"
+        },
+        {
+            "name": "zendframework/zendoauth",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/ZendOAuth.git",
+                "reference": "36defad317aa80ac9366f5e5171dc0316f009f13"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/ZendOAuth/zipball/36defad317aa80ac9366f5e5171dc0316f009f13",
+                "reference": "36defad317aa80ac9366f5e5171dc0316f009f13",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "zendframework/zend-config": ">=2.0.0",
+                "zendframework/zend-crypt": ">=2.0.0",
+                "zendframework/zend-http": ">=2.0.0",
+                "zendframework/zend-i18n": ">=2.0.0",
+                "zendframework/zend-loader": ">=2.0.0",
+                "zendframework/zend-math": ">=2.0.0",
+                "zendframework/zend-stdlib": ">=2.0.0",
+                "zendframework/zend-uri": ">=2.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "ZendOAuth": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "http://packages.zendframework.com/",
+            "keywords": [
+                "oauth",
+                "zf2"
+            ],
+            "time": "2014-04-09 01:02:18"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3,<8.0-DEV"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1.8",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://github.com/doctrine/instantiator",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2015-06-14 21:17:01"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "a8773992b362b58498eed24bf85005f363c34771"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/a8773992b362b58498eed24bf85005f363c34771",
+                "reference": "a8773992b362b58498eed24bf85005f363c34771",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "doctrine/collections": "1.*",
+                "phpunit/phpunit": "~4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "homepage": "https://github.com/myclabs/DeepCopy",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2015-11-20 12:04:31"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2015-12-27 11:43:31"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "9270140b940ff02e58ec577c237274e92cd40cdd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/9270140b940ff02e58ec577c237274e92cd40cdd",
+                "reference": "9270140b940ff02e58ec577c237274e92cd40cdd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "phpdocumentor/reflection-common": "^1.0@dev",
+                "phpdocumentor/type-resolver": "^0.2.0",
+                "webmozart/assert": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^4.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2016-06-10 09:48:41"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/b39c7a5b194f9ed7bd0dd345c751007a41862443",
+                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "phpdocumentor/reflection-common": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "time": "2016-06-10 07:14:17"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "v1.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "58a8137754bc24b25740d4281399a4a3596058e0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/58a8137754bc24b25740d4281399a4a3596058e0",
+                "reference": "58a8137754bc24b25740d4281399a4a3596058e0",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
+                "sebastian/comparator": "^1.1",
+                "sebastian/recursion-context": "^1.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Prophecy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "time": "2016-06-07 08:13:47"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "5f3f7e736d6319d5f1fc402aff8b026da26709a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/5f3f7e736d6319d5f1fc402aff8b026da26709a3",
+                "reference": "5f3f7e736d6319d5f1fc402aff8b026da26709a3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-file-iterator": "~1.3",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-token-stream": "^1.4.2",
+                "sebastian/code-unit-reverse-lookup": "~1.0",
+                "sebastian/environment": "^1.3.2 || ^2.0",
+                "sebastian/version": "~1.0|~2.0"
+            },
+            "require-dev": {
+                "ext-xdebug": ">=2.1.4",
+                "phpunit/phpunit": "^5.4"
+            },
+            "suggest": {
+                "ext-dom": "*",
+                "ext-xdebug": ">=2.4.0",
+                "ext-xmlwriter": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2016-07-26 14:39:29"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2015-06-21 13:08:43"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2015-06-21 13:50:34"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4|~5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2016-05-12 18:03:57"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "1.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2015-09-15 10:49:45"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "5.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "3132365e1430c091f208e120b8845d39c25f20e6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3132365e1430c091f208e120b8845d39c25f20e6",
+                "reference": "3132365e1430c091f208e120b8845d39c25f20e6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "myclabs/deep-copy": "~1.3",
+                "php": "^5.6 || ^7.0",
+                "phpspec/prophecy": "^1.3.1",
+                "phpunit/php-code-coverage": "^4.0.1",
+                "phpunit/php-file-iterator": "~1.4",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-timer": "^1.0.6",
+                "phpunit/phpunit-mock-objects": "^3.2",
+                "sebastian/comparator": "~1.1",
+                "sebastian/diff": "~1.2",
+                "sebastian/environment": "^1.3 || ^2.0",
+                "sebastian/exporter": "~1.2",
+                "sebastian/global-state": "~1.0",
+                "sebastian/object-enumerator": "~1.0",
+                "sebastian/resource-operations": "~1.0",
+                "sebastian/version": "~1.0|~2.0",
+                "symfony/yaml": "~2.1|~3.0"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "3.0.2"
+            },
+            "suggest": {
+                "phpunit/php-invoker": "~1.1"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.4.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2016-07-26 14:48:00"
+        },
+        {
+            "name": "phpunit/phpunit-mock-objects",
+            "version": "3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+                "reference": "b13d0d9426ced06958bd32104653526a6c998a52"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/b13d0d9426ced06958bd32104653526a6c998a52",
+                "reference": "b13d0d9426ced06958bd32104653526a6c998a52",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-text-template": "^1.2",
+                "sebastian/exporter": "^1.2"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.4"
+            },
+            "suggest": {
+                "ext-soap": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Mock Object library for PHPUnit",
+            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "keywords": [
+                "mock",
+                "xunit"
+            ],
+            "time": "2016-06-12 07:37:26"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
+                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2016-02-13 06:45:14"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
+                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/diff": "~1.2",
+                "sebastian/exporter": "~1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "time": "2015-07-26 15:48:44"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2015-12-08 07:14:41"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "1.3.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/4e8f0da10ac5802913afc151413bc8c53b6c2716",
+                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "time": "2016-05-17 03:18:57"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/recursion-context": "~1.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2016-06-17 09:04:28"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "time": "2015-10-12 03:26:01"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/d4ca2fb70344987502567bc50081c03e6192fb26",
+                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "sebastian/recursion-context": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2016-01-28 13:25:10"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2015-11-11 19:50:13"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2015-07-28 20:34:47"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
+                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "time": "2016-02-04 12:56:52"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "2.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "4edb770cb853def6e60c93abb088ad5ac2010c83"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4edb770cb853def6e60c93abb088ad5ac2010c83",
+                "reference": "4edb770cb853def6e60c93abb088ad5ac2010c83",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "scripts/phpcs",
+                "scripts/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "CodeSniffer.php",
+                    "CodeSniffer/CLI.php",
+                    "CodeSniffer/Exception.php",
+                    "CodeSniffer/File.php",
+                    "CodeSniffer/Fixer.php",
+                    "CodeSniffer/Report.php",
+                    "CodeSniffer/Reporting.php",
+                    "CodeSniffer/Sniff.php",
+                    "CodeSniffer/Tokens.php",
+                    "CodeSniffer/Reports/",
+                    "CodeSniffer/Tokenizers/",
+                    "CodeSniffer/DocGenerators/",
+                    "CodeSniffer/Standards/AbstractPatternSniff.php",
+                    "CodeSniffer/Standards/AbstractScopeSniff.php",
+                    "CodeSniffer/Standards/AbstractVariableSniff.php",
+                    "CodeSniffer/Standards/IncorrectPatternException.php",
+                    "CodeSniffer/Standards/Generic/Sniffs/",
+                    "CodeSniffer/Standards/MySource/Sniffs/",
+                    "CodeSniffer/Standards/PEAR/Sniffs/",
+                    "CodeSniffer/Standards/PSR1/Sniffs/",
+                    "CodeSniffer/Standards/PSR2/Sniffs/",
+                    "CodeSniffer/Standards/Squiz/Sniffs/",
+                    "CodeSniffer/Standards/Zend/Sniffs/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2016-07-13 23:29:13"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "2884c26ce4c1d61aebf423a8b912950fe7c764de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/2884c26ce4c1d61aebf423a8b912950fe7c764de",
+                "reference": "2884c26ce4c1d61aebf423a8b912950fe7c764de",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-06-29 05:41:56"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "30eed06dd6bc88410a4ff7f77b6d22f3ce13dbde"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/30eed06dd6bc88410a4ff7f77b6d22f3ce13dbde",
+                "reference": "30eed06dd6bc88410a4ff7f77b6d22f3ce13dbde",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2015-08-24 13:29:44"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "^5.5 || ^7.0"
+    },
+    "platform-dev": []
+}

--- a/library/ZendService/Twitter/Response.php
+++ b/library/ZendService/Twitter/Response.php
@@ -80,7 +80,7 @@ class Response
         if (null === $this->jsonBody) {
             return null;
         }
-        if (!isset($this->jsonBody->{$name})) {
+        if (! isset($this->jsonBody->{$name})) {
             return null;
         }
         return $this->jsonBody->{$name};
@@ -103,7 +103,7 @@ class Response
      */
     public function isError()
     {
-        return !$this->httpResponse->isSuccess();
+        return ! $this->httpResponse->isSuccess();
     }
 
     /**
@@ -120,11 +120,11 @@ class Response
      */
     public function getErrors()
     {
-        if (!$this->isError()) {
-            return array();
+        if (! $this->isError()) {
+            return [];
         }
         if (null === $this->jsonBody
-            || !isset($this->jsonBody->errors)
+            || ! isset($this->jsonBody->errors)
         ) {
             throw new Exception\DomainException(
                 'Either no JSON response received, or JSON error response is malformed; cannot return errors'

--- a/library/ZendService/Twitter/Twitter.php
+++ b/library/ZendService/Twitter/Twitter.php
@@ -79,7 +79,7 @@ class Twitter
      *
      * @var array
      */
-    protected $methodTypes = array(
+    protected $methodTypes = [
         'account',
         'application',
         'blocks',
@@ -89,14 +89,14 @@ class Twitter
         'search',
         'statuses',
         'users',
-    );
+    ];
 
     /**
      * Options passed to constructor
      *
      * @var array
      */
-    protected $options = array();
+    protected $options = [];
 
     /**
      * Username
@@ -117,8 +117,8 @@ class Twitter
         if ($options instanceof Traversable) {
             $options = ArrayUtils::iteratorToArray($options);
         }
-        if (!is_array($options)) {
-            $options = array();
+        if (! is_array($options)) {
+            $options = [];
         }
 
         $this->options = $options;
@@ -134,7 +134,7 @@ class Twitter
             $accessToken = $options['access_token'];
         }
 
-        $oauthOptions = array();
+        $oauthOptions = [];
         if (isset($options['oauthOptions'])) {
             $oauthOptions = $options['oauthOptions'];
         } elseif (isset($options['oauth_options'])) {
@@ -142,7 +142,7 @@ class Twitter
         }
         $oauthOptions['siteUrl'] = static::OAUTH_BASE_URI;
 
-        $httpClientOptions = array();
+        $httpClientOptions = [];
         if (isset($options['httpClientOptions'])) {
             $httpClientOptions = $options['httpClientOptions'];
         } elseif (isset($options['http_client_options'])) {
@@ -160,7 +160,11 @@ class Twitter
         }
         if ($accessToken && $accessToken instanceof OAuth\Token\Access) {
             $oauthOptions['token'] = $accessToken;
-            $this->setHttpClient($accessToken->getHttpClient($oauthOptions, static::OAUTH_BASE_URI, $httpClientOptions));
+            $this->setHttpClient($accessToken->getHttpClient(
+                $oauthOptions,
+                static::OAUTH_BASE_URI,
+                $httpClientOptions
+            ));
             return;
         }
 
@@ -194,7 +198,7 @@ class Twitter
     {
         $type = strtolower($type);
         $type = str_replace('_', '', $type);
-        if (!in_array($type, $this->methodTypes)) {
+        if (! in_array($type, $this->methodTypes)) {
             throw new Exception\DomainException(
                 'Invalid method type "' . $type . '"'
             );
@@ -214,7 +218,7 @@ class Twitter
     public function __call($method, $params)
     {
         if (method_exists($this->oauthConsumer, $method)) {
-            $return = call_user_func_array(array($this->oauthConsumer, $method), $params);
+            $return = call_user_func_array([$this->oauthConsumer, $method], $params);
             if ($return instanceof OAuth\Token\Access) {
                 $this->setHttpClient($return->getHttpClient($this->options));
             }
@@ -228,13 +232,13 @@ class Twitter
 
         $test = str_replace('_', '', strtolower($method));
         $test = $this->methodType . $test;
-        if (!method_exists($this, $test)) {
+        if (! method_exists($this, $test)) {
             throw new Exception\BadMethodCallException(
                 'Invalid method "' . $test . '"'
             );
         }
 
-        return call_user_func_array(array($this, $test), $params);
+        return call_user_func_array([$this, $test], $params);
     }
 
     /**
@@ -246,7 +250,7 @@ class Twitter
     public function setHttpClient(Http\Client $client)
     {
         $this->httpClient = $client;
-        $this->httpClient->setHeaders(array('Accept-Charset' => 'ISO-8859-1,utf-8'));
+        $this->httpClient->setHeaders(['Accept-Charset' => 'ISO-8859-1,utf-8']);
         return $this;
     }
 
@@ -341,7 +345,7 @@ class Twitter
     {
         $this->init();
         $path     = 'blocks/create';
-        $params   = $this->createUserParameter($id, array());
+        $params   = $this->createUserParameter($id, []);
         $response = $this->post($path, $params);
         return new Response($response);
     }
@@ -357,7 +361,7 @@ class Twitter
     {
         $this->init();
         $path   = 'blocks/destroy';
-        $params = $this->createUserParameter($id, array());
+        $params = $this->createUserParameter($id, []);
         $response = $this->post($path, $params);
         return new Response($response);
     }
@@ -365,7 +369,8 @@ class Twitter
     /**
      * Returns an array of user ids that the authenticating user is blocking
      *
-     * @param  integer $cursor  Optional. Specifies the cursor position at which to begin listing ids; defaults to first "page" of results.
+     * @param  integer $cursor  Optional. Specifies the cursor position at
+     *     which to begin listing ids; defaults to first "page" of results.
      * @throws Exception\DomainException if unable to decode JSON payload
      * @return Response
      */
@@ -373,14 +378,15 @@ class Twitter
     {
         $this->init();
         $path = 'blocks/ids';
-        $response = $this->get($path, array('cursor' => $cursor));
+        $response = $this->get($path, ['cursor' => $cursor]);
         return new Response($response);
     }
 
     /**
      * Returns an array of user objects that the authenticating user is blocking
      *
-     * @param  integer $cursor  Optional. Specifies the cursor position at which to begin listing ids; defaults to first "page" of results.
+     * @param  integer $cursor  Optional. Specifies the cursor position at
+     *     which to begin listing ids; defaults to first "page" of results.
      * @throws Exception\DomainException if unable to decode JSON payload
      * @return Response
      */
@@ -388,7 +394,7 @@ class Twitter
     {
         $this->init();
         $path = 'blocks/list';
-        $response = $this->get($path, array('cursor' => $cursor));
+        $response = $this->get($path, ['cursor' => $cursor]);
         return new Response($response);
     }
 
@@ -404,7 +410,7 @@ class Twitter
     {
         $this->init();
         $path     = 'direct_messages/destroy';
-        $params   = array('id' => $this->validInteger($id));
+        $params   = ['id' => $this->validInteger($id)];
         $response = $this->post($path, $params);
         return new Response($response);
     }
@@ -424,11 +430,11 @@ class Twitter
      * @throws Exception\DomainException if unable to decode JSON payload
      * @return Response
      */
-    public function directMessagesMessages(array $options = array())
+    public function directMessagesMessages(array $options = [])
     {
         $this->init();
         $path   = 'direct_messages';
-        $params = array();
+        $params = [];
         foreach ($options as $key => $value) {
             switch (strtolower($key)) {
                 case 'count':
@@ -481,7 +487,7 @@ class Twitter
             );
         }
 
-        $params         = $this->createUserParameter($user, array());
+        $params         = $this->createUserParameter($user, []);
         $params['text'] = $text;
         $response       = $this->post($path, $params);
         return new Response($response);
@@ -502,11 +508,11 @@ class Twitter
      * @throws Exception\DomainException if unable to decode JSON payload
      * @return Response
      */
-    public function directMessagesSent(array $options = array())
+    public function directMessagesSent(array $options = [])
     {
         $this->init();
         $path   = 'direct_messages/sent';
-        $params = array();
+        $params = [];
         foreach ($options as $key => $value) {
             switch (strtolower($key)) {
                 case 'count':
@@ -544,7 +550,7 @@ class Twitter
     {
         $this->init();
         $path     = 'favorites/create';
-        $params   = array('id' => $this->validInteger($id));
+        $params   = ['id' => $this->validInteger($id)];
         $response = $this->post($path, $params);
         return new Response($response);
     }
@@ -561,7 +567,7 @@ class Twitter
     {
         $this->init();
         $path     = 'favorites/destroy';
-        $params   = array('id' => $this->validInteger($id));
+        $params   = ['id' => $this->validInteger($id)];
         $response = $this->post($path, $params);
         return new Response($response);
     }
@@ -582,11 +588,11 @@ class Twitter
      * @throws Exception\DomainException if unable to decode JSON payload
      * @return Response
      */
-    public function favoritesList(array $options = array())
+    public function favoritesList(array $options = [])
     {
         $this->init();
         $path = 'favorites/list';
-        $params = array();
+        $params = [];
         foreach ($options as $key => $value) {
             switch (strtolower($key)) {
                 case 'user_id':
@@ -624,16 +630,16 @@ class Twitter
      * @throws Exception\DomainException if unable to decode JSON payload
      * @return Response
      */
-    public function friendshipsCreate($id, array $params = array())
+    public function friendshipsCreate($id, array $params = [])
     {
         $this->init();
         $path    = 'friendships/create';
         $params  = $this->createUserParameter($id, $params);
-        $allowed = array(
+        $allowed = [
             'user_id'     => null,
             'screen_name' => null,
             'follow'      => null,
-        );
+        ];
         $params = array_intersect_key($params, $allowed);
         $response = $this->post($path, $params);
         return new Response($response);
@@ -651,7 +657,7 @@ class Twitter
     {
         $this->init();
         $path     = 'friendships/destroy';
-        $params   = $this->createUserParameter($id, array());
+        $params   = $this->createUserParameter($id, []);
         $response = $this->post($path, $params);
         return new Response($response);
     }
@@ -676,7 +682,7 @@ class Twitter
      * @throws Exception\DomainException if unable to decode JSON payload
      * @return Response
      */
-    public function searchTweets($query, array $options = array())
+    public function searchTweets($query, array $options = [])
     {
         $this->init();
         $path = 'search/tweets';
@@ -688,18 +694,18 @@ class Twitter
             );
         }
 
-        $params = array('q' => $query);
+        $params = ['q' => $query];
         foreach ($options as $key => $value) {
             switch (strtolower($key)) {
                 case 'geocode':
-                    if (!substr_count($value, ',') !== 2) {
+                    if (! substr_count($value, ',') !== 2) {
                         throw new Exception\InvalidArgumentException(
                             '"geocode" must be of the format "latitude,longitude,radius"'
                         );
                     }
                     list($latitude, $longitude, $radius) = explode(',', $value);
                     $radius = trim($radius);
-                    if (!preg_match('/^\d+(mi|km)$/', $radius)) {
+                    if (! preg_match('/^\d+(mi|km)$/', $radius)) {
                         throw new Exception\InvalidArgumentException(
                             'Radius segment of "geocode" must be of the format "[unit](mi|km)"'
                         );
@@ -726,7 +732,7 @@ class Twitter
                     break;
                 case 'result_type':
                     $value = strtolower($value);
-                    if (!in_array($value, array('mixed', 'recent', 'popular'))) {
+                    if (! in_array($value, ['mixed', 'recent', 'popular'])) {
                         throw new Exception\InvalidArgumentException(
                             'result_type must be one of "mixed", "recent", or "popular"'
                         );
@@ -743,7 +749,7 @@ class Twitter
                     $params['count'] = $value;
                     break;
                 case 'until':
-                    if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $value)) {
+                    if (! preg_match('/^\d{4}-\d{2}-\d{2}$/', $value)) {
                         throw new Exception\InvalidArgumentException(
                             '"until" must be a date in the format YYYY-MM-DD'
                         );
@@ -800,11 +806,11 @@ class Twitter
      * @throws Exception\DomainException if unable to decode JSON payload
      * @return Response
      */
-    public function statusesHomeTimeline(array $options = array())
+    public function statusesHomeTimeline(array $options = [])
     {
         $this->init();
         $path = 'statuses/home_timeline';
-        $params = array();
+        $params = [];
         foreach ($options as $key => $value) {
             switch (strtolower($key)) {
                 case 'count':
@@ -817,7 +823,7 @@ class Twitter
                     $params['max_id'] = $this->validInteger($value);
                     break;
                 case 'trim_user':
-                    if (in_array($value, array(true, 'true', 't', 1, '1'))) {
+                    if (in_array($value, [true, 'true', 't', 1, '1'])) {
                         $value = true;
                     } else {
                         $value = false;
@@ -857,11 +863,11 @@ class Twitter
      * @throws Exception\DomainException if unable to decode JSON payload
      * @return Response
      */
-    public function statusesMentionsTimeline(array $options = array())
+    public function statusesMentionsTimeline(array $options = [])
     {
         $this->init();
         $path   = 'statuses/mentions_timeline';
-        $params = array();
+        $params = [];
         foreach ($options as $key => $value) {
             switch (strtolower($key)) {
                 case 'count':
@@ -874,7 +880,7 @@ class Twitter
                     $params['max_id'] = $this->validInteger($value);
                     break;
                 case 'trim_user':
-                    if (in_array($value, array(true, 'true', 't', 1, '1'))) {
+                    if (in_array($value, [true, 'true', 't', 1, '1'])) {
                         $value = true;
                     } else {
                         $value = false;
@@ -955,7 +961,7 @@ class Twitter
             );
         }
 
-        $params = array('status' => $status);
+        $params = ['status' => $status];
         $inReplyToStatusId = $this->validInteger($inReplyToStatusId);
         if ($inReplyToStatusId) {
             $params['in_reply_to_status_id'] = $inReplyToStatusId;
@@ -982,11 +988,11 @@ class Twitter
      * @throws Exception\DomainException if unable to decode JSON payload
      * @return Response
      */
-    public function statusesUserTimeline(array $options = array())
+    public function statusesUserTimeline(array $options = [])
     {
         $this->init();
         $path = 'statuses/user_timeline';
-        $params = array();
+        $params = [];
         foreach ($options as $key => $value) {
             switch (strtolower($key)) {
                 case 'user_id':
@@ -1005,7 +1011,7 @@ class Twitter
                     $params['max_id'] = $this->validInteger($value);
                     break;
                 case 'trim_user':
-                    if (in_array($value, array(true, 'true', 't', 1, '1'))) {
+                    if (in_array($value, [true, 'true', 't', 1, '1'])) {
                         $value = true;
                     } else {
                         $value = false;
@@ -1043,7 +1049,7 @@ class Twitter
      * @throws Exception\DomainException if unable to decode JSON payload
      * @return Response
      */
-    public function usersSearch($query, array $options = array())
+    public function usersSearch($query, array $options = [])
     {
         $this->init();
         $path = 'users/search';
@@ -1055,7 +1061,7 @@ class Twitter
             );
         }
 
-        $params = array('q' => $query);
+        $params = ['q' => $query];
         foreach ($options as $key => $value) {
             switch (strtolower($key)) {
                 case 'count':
@@ -1094,7 +1100,7 @@ class Twitter
     {
         $this->init();
         $path     = 'users/show';
-        $params   = $this->createUserParameter($id, array());
+        $params   = $this->createUserParameter($id, []);
         $response = $this->get($path, $params);
         return new Response($response);
     }
@@ -1107,7 +1113,7 @@ class Twitter
      */
     protected function init()
     {
-        if (!$this->isAuthorised() && $this->getUsername() !== null) {
+        if (! $this->isAuthorised() && $this->getUsername() !== null) {
             throw new Exception\DomainException(
                 'Twitter session is unauthorised. You need to initialize '
                 . __CLASS__ . ' with an OAuth Access Token or use '
@@ -1149,11 +1155,12 @@ class Twitter
      */
     protected function validateScreenName($name)
     {
-        if (!preg_match('/^[a-zA-Z0-9_]{0,20}$/', $name)) {
+        if (! preg_match('/^[a-zA-Z0-9_]{0,20}$/', $name)) {
             throw new Exception\InvalidArgumentException(
                 'Screen name, "' . $name
                 . '" should only contain alphanumeric characters and'
-                . ' underscores, and not exceed 15 characters.');
+                . ' underscores, and not exceed 15 characters.'
+            );
         }
         return $name;
     }
@@ -1184,7 +1191,7 @@ class Twitter
      * @throws Http\Client\Exception\ExceptionInterface
      * @return Http\Response
      */
-    protected function get($path, array $query = array())
+    protected function get($path, array $query = [])
     {
         $client = $this->getHttpClient();
         $this->prepare($path, $client);

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<ruleset name="Zend Framework coding standard">
+    <description>Zend Framework coding standard</description>
+
+    <!-- display progress -->
+    <arg value="p"/>
+    <arg name="colors"/>
+
+    <!-- inherit rules from: -->
+    <rule ref="PSR2"/>
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+    <rule ref="Generic.Formatting.SpaceAfterNot"/>
+    <rule ref="Squiz.WhiteSpace.OperatorSpacing">
+        <properties>
+            <property name="ignoreNewlines" value="true"/>
+        </properties>
+    </rule>
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
+        <properties>
+            <property name="ignoreBlankLines" value="false"/>
+        </properties>
+    </rule>
+
+    <!-- Paths to check -->
+    <file>library</file>
+    <file>tests</file>
+</ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
-<phpunit bootstrap="./Bootstrap.php" colors="true">
+<phpunit bootstrap="./tests/Bootstrap.php" colors="true">
     <testsuites>
         <testsuite name="ZendService Twitter Test Suite">
-            <directory>./ZendService</directory>
+            <directory>./tests/ZendService</directory>
         </testsuite>
     </testsuites>
 

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -11,14 +11,7 @@
 /*
  * Set error reporting to the level to which Zend Framework code must comply.
  */
-error_reporting( E_ALL | E_STRICT );
-
-$phpUnitVersion = PHPUnit_Runner_Version::id();
-if ('@package_version@' !== $phpUnitVersion && version_compare($phpUnitVersion, '3.5.0', '<')) {
-    echo 'This version of PHPUnit (' . PHPUnit_Runner_Version::id() . ') is not supported in Zend Framework 2.x unit tests.' . PHP_EOL;
-    exit(1);
-}
-unset($phpUnitVersion);
+error_reporting(E_ALL | E_STRICT);
 
 /*
  * Determine the root, library, and tests directories of the framework
@@ -34,11 +27,11 @@ $zfCoreTests   = "$zfRoot/tests";
  * loading other copies of the framework code and tests that would supersede
  * this copy.
  */
-$path = array(
+$path = [
     $zfCoreLibrary,
     $zfCoreTests,
     get_include_path(),
-);
+];
 set_include_path(implode(PATH_SEPARATOR, $path));
 
 /**

--- a/tests/ZendService/Twitter/TwitterTest.php
+++ b/tests/ZendService/Twitter/TwitterTest.php
@@ -44,13 +44,15 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
      */
     protected function stubTwitter($path, $method, $responseFile = null, array $params = null)
     {
-        $client = $this->getMock('ZendOAuth\Client', array(), array(), '', false);
+        $client = $this->getMockBuilder('ZendOAuth\Client', [], [], '', false)
+            ->disableOriginalConstructor()
+            ->getMock();
         $client->expects($this->any())->method('resetParameters')
             ->will($this->returnValue($client));
         $client->expects($this->once())->method('setUri')
             ->with('https://api.twitter.com/1.1/' . $path);
-        $response = $this->getMock('Zend\Http\Response', array(), array(), '', false);
-        if (!is_null($params)) {
+        $response = $this->getMockBuilder('Zend\Http\Response', [], [], '', false)->getMock();
+        if (! is_null($params)) {
             $setter = 'setParameter' . ucfirst(strtolower($method));
             $client->expects($this->once())->method($setter)->with($params);
         }
@@ -58,7 +60,7 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($response));
         $response->expects($this->any())->method('getBody')
             ->will($this->returnValue(
-                isset($responseFile) ? file_get_contents(__DIR__ . '/_files/' . $responseFile) : ''
+                isset($responseFile) ? file_get_contents(__DIR__ . '/_files/' . $responseFile) : '{}'
             ));
         return $client;
     }
@@ -69,13 +71,15 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
 
     public function testProvidingAccessTokenInOptionsSetsHttpClientFromAccessToken()
     {
-        $token = $this->getMock('ZendOAuth\Token\Access', array(), array(), '', false);
-        $client = $this->getMock('ZendOAuth\Client', array(), array(), '', false);
+        $token = $this->getMockBuilder('ZendOAuth\Token\Access', [], [], '', false)->getMock();
+        $client = $this->getMockBuilder('ZendOAuth\Client', [], [], '', false)
+            ->disableOriginalConstructor()
+            ->getMock();
         $token->expects($this->once())->method('getHttpClient')
-            ->with(array('token'=>$token, 'siteUrl'=>'https://api.twitter.com/oauth'))
+            ->with(['token' => $token, 'siteUrl' => 'https://api.twitter.com/oauth'])
             ->will($this->returnValue($client));
 
-        $twitter = new Twitter\Twitter(array('accessToken'=>$token, 'opt1'=>'val1'));
+        $twitter = new Twitter\Twitter(['accessToken' => $token, 'opt1' => 'val1']);
         $this->assertTrue($client === $twitter->getHttpClient());
     }
 
@@ -87,52 +91,59 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
 
     public function testChecksAuthenticatedStateBasedOnAvailabilityOfAccessTokenBasedClient()
     {
-        $token = $this->getMock('ZendOAuth\Token\Access', array(), array(), '', false);
-        $client = $this->getMock('ZendOAuth\Client', array(), array(), '', false);
+        $token = $this->getMockBuilder('ZendOAuth\Token\Access', [], [], '', false)->getMock();
+        $client = $this->getMockBuilder('ZendOAuth\Client', [], [], '', false)
+            ->disableOriginalConstructor()
+            ->getMock();
         $token->expects($this->once())->method('getHttpClient')
-            ->with(array('token'=>$token, 'siteUrl'=>'https://api.twitter.com/oauth'))
+            ->with(['token' => $token, 'siteUrl' => 'https://api.twitter.com/oauth'])
             ->will($this->returnValue($client));
 
-        $twitter = new Twitter\Twitter(array('accessToken'=>$token));
+        $twitter = new Twitter\Twitter(['accessToken' => $token]);
         $this->assertTrue($twitter->isAuthorised());
     }
 
     public function testRelaysMethodsToInternalOAuthInstance()
     {
-        $oauth = $this->getMock('ZendOAuth\Consumer', array(), array(), '', false);
+        $oauth = $this->getMockBuilder('ZendOAuth\Consumer', [], [], '', false)->getMock();
         $oauth->expects($this->once())->method('getRequestToken')->will($this->returnValue('foo'));
         $oauth->expects($this->once())->method('getRedirectUrl')->will($this->returnValue('foo'));
         $oauth->expects($this->once())->method('redirect')->will($this->returnValue('foo'));
         $oauth->expects($this->once())->method('getAccessToken')->will($this->returnValue('foo'));
         $oauth->expects($this->once())->method('getToken')->will($this->returnValue('foo'));
 
-        $twitter = new Twitter\Twitter(array('opt1'=>'val1'), $oauth);
+        $twitter = new Twitter\Twitter(['opt1' => 'val1'], $oauth);
         $this->assertEquals('foo', $twitter->getRequestToken());
         $this->assertEquals('foo', $twitter->getRedirectUrl());
         $this->assertEquals('foo', $twitter->redirect());
-        $this->assertEquals('foo', $twitter->getAccessToken(array(), $this->getMock('ZendOAuth\Token\Request')));
+        $this->assertEquals('foo', $twitter->getAccessToken(
+            [],
+            $this->getMockBuilder('ZendOAuth\Token\Request')->getMock()
+        ));
         $this->assertEquals('foo', $twitter->getToken());
     }
 
     public function testResetsHttpClientOnReceiptOfAccessTokenToOauthClient()
     {
         $this->markTestIncomplete('Problem with resolving classes for mocking');
-        $oauth = $this->getMock('ZendOAuth\Consumer', array(), array(), '', false);
-        $client = $this->getMock('ZendOAuth\Client', array(), array(), '', false);
-        $token = $this->getMock('ZendOAuth\Token\Access', array(), array(), '', false);
+        $oauth = $this->getMockBuilder('ZendOAuth\Consumer', [], [], '', false)->getMock();
+        $client = $this->getMockBuilder('ZendOAuth\Client', [], [], '', false)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $token = $this->getMockBuilder('ZendOAuth\Token\Access', [], [], '', false)->getMock();
         $token->expects($this->once())->method('getHttpClient')->will($this->returnValue($client));
         $oauth->expects($this->once())->method('getAccessToken')->will($this->returnValue($token));
         $client->expects($this->once())->method('setHeaders')->with('Accept-Charset', 'ISO-8859-1,utf-8');
 
-        $twitter = new Twitter\Twitter(array(), $oauth);
-        $twitter->getAccessToken(array(), $this->getMock('ZendOAuth\Token\Request'));
+        $twitter = new Twitter\Twitter([], $oauth);
+        $twitter->getAccessToken([], $this->getMockBuilder('ZendOAuth\Token\Request')->getMock());
         $this->assertTrue($client === $twitter->getHttpClient());
     }
 
     public function testAuthorisationFailureWithUsernameAndNoAccessToken()
     {
         $this->setExpectedException('ZendService\Twitter\Exception\ExceptionInterface');
-        $twitter = new Twitter\Twitter(array('username'=>'me'));
+        $twitter = new Twitter\Twitter(['username' => 'me']);
         $twitter->statusesPublicTimeline();
     }
 
@@ -143,8 +154,10 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $twitter = new Twitter\Twitter();
         $twitter->setHttpClient($this->stubTwitter(
-            'users/show.json', Http\Request::METHOD_GET, 'users.show.mwop.json',
-            array('screen_name' => 'mwop')
+            'users/show.json',
+            Http\Request::METHOD_GET,
+            'users.show.mwop.json',
+            ['screen_name' => 'mwop']
         ));
         $response = $twitter->users->show('mwop');
         $this->assertInstanceOf('ZendService\Twitter\Response', $response);
@@ -159,9 +172,11 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $twitter = new Twitter\Twitter();
         $twitter->setHttpClient($this->stubTwitter(
-            'statuses/user_timeline.json', Http\Request::METHOD_GET, 'statuses.user_timeline.mwop.json'
+            'statuses/user_timeline.json',
+            Http\Request::METHOD_GET,
+            'statuses.user_timeline.mwop.json'
         ));
-        $twitter->statuses->userTimeline(array('screen_name' => 'mwop'));
+        $twitter->statuses->userTimeline(['screen_name' => 'mwop']);
     }
 
     /**
@@ -171,7 +186,7 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('ZendService\Twitter\Exception\ExceptionInterface');
         $twitter = new Twitter\Twitter();
-        $twitter->statuses->userTimeline(array('screen_name' => 'abc.def'));
+        $twitter->statuses->userTimeline(['screen_name' => 'abc.def']);
     }
 
     /**
@@ -181,7 +196,7 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('\ZendService\Twitter\Exception\ExceptionInterface');
         $twitter = new Twitter\Twitter();
-        $twitter->statuses->userTimeline(array('screen_name' => 'abcdef_abc123_abc123x'));
+        $twitter->statuses->userTimeline(['screen_name' => 'abcdef_abc123_abc123x']);
     }
 
     /**
@@ -191,15 +206,18 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $twitter = new Twitter\Twitter;
         $twitter->setHttpClient($this->stubTwitter(
-            'statuses/user_timeline.json', Http\Request::METHOD_GET, 'statuses.user_timeline.mwop.json', array(
+            'statuses/user_timeline.json',
+            Http\Request::METHOD_GET,
+            'statuses.user_timeline.mwop.json',
+            [
                 'count' => '123',
                 'user_id' => 783214,
                 'since_id' => '10000',
                 'max_id' => '20000',
-                'screen_name' => 'twitter'
-            )
+                'screen_name' => 'twitter',
+            ]
         ));
-        $twitter->statuses->userTimeline(array(
+        $twitter->statuses->userTimeline([
             'id' => '783214',
             'since' => '+2 days', /* invalid param since Apr 2009 */
             'page' => '1',
@@ -208,7 +226,7 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
             'since_id' => '10000',
             'max_id' => '20000',
             'screen_name' => 'twitter'
-        ));
+        ]);
     }
 
     public function testOverloadingGetShouldReturnObjectInstanceWithValidMethodType()
@@ -236,7 +254,9 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $twitter = new Twitter\Twitter;
         $twitter->setHttpClient($this->stubTwitter(
-            'statuses/sample.json', Http\Request::METHOD_GET, 'statuses.sample.json'
+            'statuses/sample.json',
+            Http\Request::METHOD_GET,
+            'statuses.sample.json'
         ));
         $twitter->statuses->sample();
     }
@@ -252,7 +272,9 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $twitter = new Twitter\Twitter;
         $twitter->setHttpClient($this->stubTwitter(
-            'account/verify_credentials.json', Http\Request::METHOD_GET, 'account.verify_credentials.json'
+            'account/verify_credentials.json',
+            Http\Request::METHOD_GET,
+            'account.verify_credentials.json'
         ));
         $response = $twitter->account->verifyCredentials();
         $this->assertTrue($response instanceof TwitterResponse);
@@ -262,7 +284,9 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $twitter = new Twitter\Twitter;
         $twitter->setHttpClient($this->stubTwitter(
-            'statuses/sample.json', Http\Request::METHOD_GET, 'statuses.sample.json'
+            'statuses/sample.json',
+            Http\Request::METHOD_GET,
+            'statuses.sample.json'
         ));
         $response = $twitter->statuses->sample();
         $this->assertTrue($response instanceof TwitterResponse);
@@ -272,7 +296,9 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $twitter = new Twitter\Twitter;
         $twitter->setHttpClient($this->stubTwitter(
-            'application/rate_limit_status.json', Http\Request::METHOD_GET, 'application.rate_limit_status.json'
+            'application/rate_limit_status.json',
+            Http\Request::METHOD_GET,
+            'application.rate_limit_status.json'
         ));
         $response = $twitter->application->rateLimitStatus();
         $this->assertTrue($response instanceof TwitterResponse);
@@ -282,7 +308,9 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $twitter = new Twitter\Twitter;
         $twitter->setHttpClient($this->stubTwitter(
-            'application/rate_limit_status.json', Http\Request::METHOD_GET, 'application.rate_limit_status.json'
+            'application/rate_limit_status.json',
+            Http\Request::METHOD_GET,
+            'application.rate_limit_status.json'
         ));
         $response = $twitter->application->rateLimitStatus();
         $status = $response->toValue();
@@ -297,8 +325,10 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $twitter = new Twitter\Twitter;
         $twitter->setHttpClient($this->stubTwitter(
-            'friendships/create.json', Http\Request::METHOD_POST, 'friendships.create.twitter.json',
-            array('screen_name' => 'twitter')
+            'friendships/create.json',
+            Http\Request::METHOD_POST,
+            'friendships.create.twitter.json',
+            ['screen_name' => 'twitter']
         ));
         $response = $twitter->friendships->create('twitter');
         $this->assertTrue($response instanceof TwitterResponse);
@@ -308,10 +338,12 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $twitter = new Twitter\Twitter;
         $twitter->setHttpClient($this->stubTwitter(
-            'statuses/home_timeline.json', Http\Request::METHOD_GET, 'statuses.home_timeline.page.json',
-            array('count' => 3)
+            'statuses/home_timeline.json',
+            Http\Request::METHOD_GET,
+            'statuses.home_timeline.page.json',
+            ['count' => 3]
         ));
-        $response = $twitter->statuses->homeTimeline(array('count' => 3));
+        $response = $twitter->statuses->homeTimeline(['count' => 3]);
         $this->assertTrue($response instanceof TwitterResponse);
     }
 
@@ -322,10 +354,12 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $twitter = new Twitter\Twitter;
         $twitter->setHttpClient($this->stubTwitter(
-            'statuses/user_timeline.json', Http\Request::METHOD_GET, 'statuses.user_timeline.mwop.json',
-            array('screen_name' => 'mwop')
+            'statuses/user_timeline.json',
+            Http\Request::METHOD_GET,
+            'statuses.user_timeline.mwop.json',
+            ['screen_name' => 'mwop']
         ));
-        $response = $twitter->statuses->userTimeline(array('screen_name' => 'mwop'));
+        $response = $twitter->statuses->userTimeline(['screen_name' => 'mwop']);
         $this->assertTrue($response instanceof TwitterResponse);
     }
 
@@ -336,8 +370,10 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $twitter = new Twitter\Twitter;
         $twitter->setHttpClient($this->stubTwitter(
-            'statuses/update.json', Http\Request::METHOD_POST, 'statuses.update.json',
-            array('status'=>'Test Message 1')
+            'statuses/update.json',
+            Http\Request::METHOD_POST,
+            'statuses.update.json',
+            ['status' => 'Test Message 1']
         ));
         $response = $twitter->statuses->update('Test Message 1');
         $this->assertTrue($response instanceof TwitterResponse);
@@ -361,7 +397,9 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $twitter = new Twitter\Twitter;
         $twitter->setHttpClient($this->stubTwitter(
-            'statuses/show/307529814640840705.json', Http\Request::METHOD_GET, 'statuses.show.json'
+            'statuses/show/307529814640840705.json',
+            Http\Request::METHOD_GET,
+            'statuses.show.json'
         ));
         $response = $twitter->statuses->show('307529814640840705');
         $this->assertTrue($response instanceof TwitterResponse);
@@ -371,8 +409,10 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $twitter = new Twitter\Twitter;
         $twitter->setHttpClient($this->stubTwitter(
-            'favorites/create.json', Http\Request::METHOD_POST, 'favorites.create.json',
-            array('id' => 15042159587)
+            'favorites/create.json',
+            Http\Request::METHOD_POST,
+            'favorites.create.json',
+            ['id' => 15042159587]
         ));
         $response = $twitter->favorites->create(15042159587);
         $this->assertTrue($response instanceof TwitterResponse);
@@ -382,7 +422,9 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $twitter = new Twitter\Twitter;
         $twitter->setHttpClient($this->stubTwitter(
-            'favorites/list.json', Http\Request::METHOD_GET, 'favorites.list.json'
+            'favorites/list.json',
+            Http\Request::METHOD_GET,
+            'favorites.list.json'
         ));
         $response = $twitter->favorites->list();
         $this->assertTrue($response instanceof TwitterResponse);
@@ -392,8 +434,10 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $twitter = new Twitter\Twitter;
         $twitter->setHttpClient($this->stubTwitter(
-            'favorites/destroy.json', Http\Request::METHOD_POST, 'favorites.destroy.json',
-            array('id' => 15042159587)
+            'favorites/destroy.json',
+            Http\Request::METHOD_POST,
+            'favorites.destroy.json',
+            ['id' => 15042159587]
         ));
         $response = $twitter->favorites->destroy(15042159587);
         $this->assertTrue($response instanceof TwitterResponse);
@@ -403,7 +447,9 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $twitter = new Twitter\Twitter;
         $twitter->setHttpClient($this->stubTwitter(
-            'statuses/destroy/15042159587.json', Http\Request::METHOD_POST, 'statuses.destroy.json'
+            'statuses/destroy/15042159587.json',
+            Http\Request::METHOD_POST,
+            'statuses.destroy.json'
         ));
         $response = $twitter->statuses->destroy(15042159587);
         $this->assertTrue($response instanceof TwitterResponse);
@@ -413,7 +459,9 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $twitter = new Twitter\Twitter;
         $twitter->setHttpClient($this->stubTwitter(
-            'statuses/home_timeline.json', Http\Request::METHOD_GET, 'statuses.home_timeline.page.json'
+            'statuses/home_timeline.json',
+            Http\Request::METHOD_GET,
+            'statuses.home_timeline.page.json'
         ));
         $response = $twitter->statuses->homeTimeline();
         $this->assertTrue($response instanceof TwitterResponse);
@@ -423,8 +471,10 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $twitter = new Twitter\Twitter;
         $twitter->setHttpClient($this->stubTwitter(
-            'users/show.json', Http\Request::METHOD_GET, 'users.show.mwop.json',
-            array('screen_name' => 'mwop')
+            'users/show.json',
+            Http\Request::METHOD_GET,
+            'users.show.mwop.json',
+            ['screen_name' => 'mwop']
         ));
         $response = $twitter->users->show('mwop');
         $this->assertTrue($response instanceof TwitterResponse);
@@ -438,7 +488,9 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $twitter = new Twitter\Twitter;
         $twitter->setHttpClient($this->stubTwitter(
-            'statuses/mentions_timeline.json', Http\Request::METHOD_GET, 'statuses.mentions_timeline.json'
+            'statuses/mentions_timeline.json',
+            Http\Request::METHOD_GET,
+            'statuses.mentions_timeline.json'
         ));
         $response = $twitter->statuses->mentionsTimeline();
         $this->assertTrue($response instanceof TwitterResponse);
@@ -451,8 +503,10 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $twitter = new Twitter\Twitter;
         $twitter->setHttpClient($this->stubTwitter(
-            'friendships/destroy.json', Http\Request::METHOD_POST, 'friendships.destroy.twitter.json',
-            array('screen_name' => 'twitter')
+            'friendships/destroy.json',
+            Http\Request::METHOD_POST,
+            'friendships.destroy.twitter.json',
+            ['screen_name' => 'twitter']
         ));
         $response = $twitter->friendships->destroy('twitter');
         $this->assertTrue($response instanceof TwitterResponse);
@@ -462,8 +516,10 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $twitter = new Twitter\Twitter;
         $twitter->setHttpClient($this->stubTwitter(
-            'blocks/create.json', Http\Request::METHOD_POST, 'blocks.create.twitter.json',
-            array('screen_name' => 'twitter')
+            'blocks/create.json',
+            Http\Request::METHOD_POST,
+            'blocks.create.twitter.json',
+            ['screen_name' => 'twitter']
         ));
         $response = $twitter->blocks->create('twitter');
         $this->assertTrue($response instanceof TwitterResponse);
@@ -473,8 +529,10 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $twitter = new Twitter\Twitter;
         $twitter->setHttpClient($this->stubTwitter(
-            'blocks/list.json', Http\Request::METHOD_GET, 'blocks.list.json',
-            array('cursor' => -1)
+            'blocks/list.json',
+            Http\Request::METHOD_GET,
+            'blocks.list.json',
+            ['cursor' => -1]
         ));
         $response = $twitter->blocks->list();
         $this->assertTrue($response instanceof TwitterResponse);
@@ -489,8 +547,9 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
                 'users/show.json',
                 Http\Request::METHOD_GET,
                 null,
-                array('screen_name' => 'JuicyBurger661')
-        ));
+                ['screen_name' => 'JuicyBurger661']
+            )
+        );
         //$id as screen_name with numbers
         $twitter->users->show('JuicyBurger661');
     }
@@ -504,11 +563,11 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
                 'users/show.json',
                 Http\Request::METHOD_GET,
                 null,
-                array('user_id' => 137307825)
-            ));
+                ['user_id' => 137307825]
+            )
+        );
         //$id as string
         $twitter->users->show('137307825');
-
     }
 
     public function testUsersShowAcceptsIdAsIntegerArgument()
@@ -520,8 +579,9 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
                 'users/show.json',
                 Http\Request::METHOD_GET,
                 null,
-                array('user_id' => 137307825)
-            ));
+                ['user_id' => 137307825]
+            )
+        );
         //$id as integer
         $twitter->users->show(137307825);
     }
@@ -530,8 +590,10 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $twitter = new Twitter\Twitter;
         $twitter->setHttpClient($this->stubTwitter(
-            'blocks/ids.json', Http\Request::METHOD_GET, 'blocks.ids.json',
-            array('cursor' => -1)
+            'blocks/ids.json',
+            Http\Request::METHOD_GET,
+            'blocks.ids.json',
+            ['cursor' => -1]
         ));
         $response = $twitter->blocks->ids();
         $this->assertTrue($response instanceof TwitterResponse);
@@ -542,8 +604,10 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $twitter = new Twitter\Twitter;
         $twitter->setHttpClient($this->stubTwitter(
-            'blocks/destroy.json', Http\Request::METHOD_POST, 'blocks.destroy.twitter.json',
-            array('screen_name' => 'twitter')
+            'blocks/destroy.json',
+            Http\Request::METHOD_POST,
+            'blocks.destroy.twitter.json',
+            ['screen_name' => 'twitter']
         ));
         $response = $twitter->blocks->destroy('twitter');
         $this->assertTrue($response instanceof TwitterResponse);
@@ -554,8 +618,8 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
      */
     public function testTwitterObjectsSoNotShareSameHttpClientToPreventConflictingAuthentication()
     {
-        $twitter1 = new Twitter\Twitter(array('username'=>'zftestuser1'));
-        $twitter2 = new Twitter\Twitter(array('username'=>'zftestuser2'));
+        $twitter1 = new Twitter\Twitter(['username' => 'zftestuser1']);
+        $twitter2 = new Twitter\Twitter(['username' => 'zftestuser2']);
         $this->assertFalse($twitter1->getHttpClient() === $twitter2->getHttpClient());
     }
 
@@ -563,8 +627,10 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $twitter = new Twitter\Twitter;
         $twitter->setHttpClient($this->stubTwitter(
-            'search/tweets.json', Http\Request::METHOD_GET, 'search.tweets.json',
-            array('q' => '#zf2')
+            'search/tweets.json',
+            Http\Request::METHOD_GET,
+            'search.tweets.json',
+            ['q' => '#zf2']
         ));
         $response = $twitter->search->tweets('#zf2');
         $this->assertTrue($response instanceof TwitterResponse);
@@ -574,54 +640,57 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     {
         $twitter = new Twitter\Twitter;
         $twitter->setHttpClient($this->stubTwitter(
-            'users/search.json', Http\Request::METHOD_GET, 'users.search.json',
-            array('q' => 'Zend')
+            'users/search.json',
+            Http\Request::METHOD_GET,
+            'users.search.json',
+            ['q' => 'Zend']
         ));
         $response = $twitter->users->search('Zend');
         $this->assertTrue($response instanceof TwitterResponse);
     }
 
-    public function providerAdapterAlwaysReachableIfSpecifiedConfiguration() {
+    public function providerAdapterAlwaysReachableIfSpecifiedConfiguration()
+    {
         $adapter = new CurlAdapter();
 
-        return array(
-            array(
-                array(
-                    'http_client_options' => array(
+        return [
+            [
+                [
+                    'http_client_options' => [
                         'adapter' => $adapter,
-                    ),
-                ),
+                    ],
+                ],
                 $adapter
-            ),
-            array(
-                array(
-                    'access_token' => array(
+            ],
+            [
+                [
+                    'access_token' => [
                         'token'  => 'some_token',
                         'secret' => 'some_secret',
-                    ),
-                    'http_client_options' => array(
+                    ],
+                    'http_client_options' => [
                         'adapter' => $adapter,
-                    ),
-                ),
+                    ],
+                ],
                 $adapter
-            ),
-            array(
-                array(
-                    'access_token' => array(
+            ],
+            [
+                [
+                    'access_token' => [
                         'token'  => 'some_token',
                         'secret' => 'some_secret',
-                    ),
-                    'oauth_options' => array(
+                    ],
+                    'oauth_options' => [
                         'consumerKey' => 'some_consumer_key',
                         'consumerSecret' => 'some_consumer_secret',
-                    ),
-                    'http_client_options' => array(
+                    ],
+                    'http_client_options' => [
                         'adapter' => $adapter,
-                    ),
-                ),
+                    ],
+                ],
                 $adapter
-            ),
-        );
+            ],
+        ];
     }
 
     /**

--- a/tests/ZendService/Twitter/_files/generate_data.php
+++ b/tests/ZendService/Twitter/_files/generate_data.php
@@ -1,30 +1,31 @@
 <?php
 use ZendService\Twitter\Twitter;
+
 require_once __DIR__ . '/../../../../vendor/autoload.php';
 
-$twitter = new Twitter(array(
-    'access_token' => array(
+$twitter = new Twitter([
+    'access_token' => [
         'token'  => '9453382-o1jag9yrT0ju8zYsIjKfLN2LMauVCqsph7JSGp0E4',
         'secret' => 'mICPQTLPcpcvvTWkc2DjHd3SkWUR6Bq4BD9yJUe4Xs',
-    ),
-    'oauth_options' => array(
+    ],
+    'oauth_options' => [
         'consumerKey' => 'k7lHQfa4D2De6If5orOIfw',
         'consumerSecret' => 'ax6VgjiYA5D75bLudAiC3gQAp63u9O2fV5PnXSd0Dq4',
-    ),
-    'http_client_options' => array(
+    ],
+    'http_client_options' => [
         'adapter' => 'Zend\Http\Client\Adapter\Curl',
-    )
-));
+    ]
+]);
 
 $response = $twitter->account->verifyCredentials();
-if (!$response->isSuccess()) {
+if (! $response->isSuccess()) {
     echo "Could not verify credentials!\n";
     var_export($response->getErrors());
     exit(2);
 }
 
 $response = $twitter->users->search('Zend');
-if (!$response->isSuccess()) {
+if (! $response->isSuccess()) {
     echo "Search failed!\n";
     var_export($response->getErrors());
     exit(2);

--- a/tests/ZendService/Twitter/_files/normalize_json.php
+++ b/tests/ZendService/Twitter/_files/normalize_json.php
@@ -1,9 +1,13 @@
 <?php
 use Zend\Json\Json;
 use Zend\Json\Decode;
-require_once '/home/matthew/tmp/composer/vendor/autoload.php';
+
+require_once __DIR__ . '/../../../../vendor/autoload.php';
 $json = file_get_contents('users.search.raw.json');
 $php  = Json::decode($json);
-$json = Json::encode($php /*, JSON_PRETTY_PRINT|JSON_UNESCAPED_UNICODE|JSON_NUMERIC_CHECK|JSON_BIGINT_AS_STRING|JSON_UNESCAPED_SLASHES */);
-$json = Json::prettyPrint($json, array('indent' => '  '));
+$json = Json::encode(
+    $php,
+    JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_NUMERIC_CHECK | JSON_BIGINT_AS_STRING | JSON_UNESCAPED_SLASHES
+);
+$json = Json::prettyPrint($json, ['indent' => '  ']);
 echo $json;

--- a/tests/_autoload.php
+++ b/tests/_autoload.php
@@ -3,7 +3,7 @@
  * Setup autoloading
  */
 
-if (!file_exists(__DIR__ . '/../vendor/autoload.php')) {
+if (! file_exists(__DIR__ . '/../vendor/autoload.php')) {
     throw new RuntimeException('This component has dependencies that are unmet.
 
 Please install composer (http://getcomposer.org), and run the following
@@ -20,8 +20,8 @@ spl_autoload_register(function ($class) {
         return false;
     }
     $normalized = str_replace('ZendServiceTest\\', '', $class);
-    $filename   = __DIR__ . '/ZendService/' . str_replace(array('\\', '_'), '/', $normalized) . '.php';
-    if (!file_exists($filename)) {
+    $filename   = __DIR__ . '/ZendService/' . str_replace(['\\', '_'], '/', $normalized) . '.php';
+    if (! file_exists($filename)) {
         return false;
     }
     return include_once $filename;


### PR DESCRIPTION
This patch builds on #18, and updates the QA tooling significantly:

- Adds phpunit and phpcs as development dependencies
- Implements the lowest/locked/latest test strategy for Travis
- Fixes CS issues
- Ensures tests run on PHP 7

It also updates the minimum required PHP version to 5.5.