### PR TITLE
Finalize media and rate limit support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,9 @@ matrix:
     - php: 7.2
 
 before_install:
- - cp tests/TestConfiguration.php.travis tests/TestConfiguration.php
- - if [[ $TRAVIS_PHP_VERSION =~ ^7.1 ]];then phpenv config-rm xdebug.ini ; fi
- - travis_retry composer self-update
+  - if [[ $TRAVIS_PHP_VERSION =~ ^7.1 ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
+  - cp tests/TestConfiguration.php.travis tests/TestConfiguration.php
+  - travis_retry composer self-update
 
 install:
   - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,46 +9,46 @@ cache:
 
 env:
   global:
-    - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
+    - COMPOSER_ARGS="--no-interaction"
 
 matrix:
-  fast_finish: true
   include:
-    - php: 5.6
+    - php: 7.1
       env:
         - DEPS=lowest
-    - php: 5.6
+    - php: 7.1
       env:
         - DEPS=locked
         - CHECK_CS=true
-    - php: 5.6
+    - php: 7.1
       env:
         - DEPS=latest
-    - php: 7.0
+    - php: 7.2
       env:
         - DEPS=lowest
-    - php: 7.0
+    - php: 7.2
       env:
         - DEPS=locked
-    - php: 7.0
+    - php: 7.2
       env:
         - DEPS=latest
+  allow_failures:
+    - php: 7.2
 
 before_install:
  - cp tests/TestConfiguration.php.travis tests/TestConfiguration.php
- - phpenv config-rm xdebug.ini
+ - if [[ $TRAVIS_PHP_VERSION =~ ^7.1 ]];then phpenv config-rm xdebug.ini ; fi
  - travis_retry composer self-update
 
 install:
+  - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
-  - travis_retry composer install $COMPOSER_ARGS
-  - composer show --installed
+  - stty cols 120 && composer show
 
 script:
- - vendor/bin/phpunit
- - if [[ $CHECK_CS == 'true' ]]; then vendor/bin/phpcs ; fi
+ - composer test
+ - if [[ $CHECK_CS == 'true' ]]; then composer cs-check ; fi
 
 notifications:
-  irc: "irc.freenode.org#zftalk.dev"
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
+- [#39](https://github.com/zendframework/ZendService_Twitter/pull/39) adds
+  support for PHP 7.1 and PHP 7.2.
+
+- [#34](https://github.com/zendframework/ZendService_Twitter/pull/34) adds
+  support for uploading media, via the new classes `ZendService\Twitter\Media`,
+  `Image`, and `Video`. In each case, instantiate the appropriate class with the
+  path to the image on the filesystem and the appropriate media type, and then
+  call `upload()` with a zend-http client. The response will contain a
+  `media_id` property, which you can then provide via the `media_ids` attribute
+  when posting a status.
+
+  ```php
+  $image = new Image('data/logo.png', 'image/png');
+  $response = $image->upload($client);
+  
+  $twitter->statusUpdate(
+      'A post with an image',
+      null,
+      ['media_ids' => [$response->media_id]]
+  );
+  ```
+
+- [#34](https://github.com/zendframework/ZendService_Twitter/pull/34) adds
+  support for Twitter's rate limit headers. Returned responses allow you to
+  query them via `getRateLimit()`, and the returned
+  `ZendService\Twitter\RateLimit` instance allows you to check the limit,
+  remaining requests, and time to reset.
+
+  ```php
+  $response = $twitter->statusUpdate('A post');
+  $rateLimit = $response->getRateLimit();
+  if ($rateLimit->remaining === 0) {
+      // Time to back off!
+      sleep($rateLimit->reset); // seconds left until reset
+  }
+  ```
+
 - [#29](https://github.com/zendframework/ZendService_Twitter/pull/29) adds
   support for:
   - retrieving a list of follower identifiers (`/followers/ids` API)
@@ -13,8 +50,19 @@ All notable changes to this project will be documented in this file, in reverse 
   - retrieving the friends of the user (`/friendships/lookup` API)
   - retrieving full user data on a list of users (`/users/lookup` API)
   - retrieving the identifiers for friends of the user (`/friends/ids` API)
+
 - [#31](https://github.com/zendframework/ZendService_Twitter/pull/31) adds
   support for PHP 7.
+
+### Changed
+
+- [#34](https://github.com/zendframework/ZendService_Twitter/pull/34) updates
+  direct message support to remove the 140 character limit.
+
+- [#34](https://github.com/zendframework/ZendService_Twitter/pull/34) updates
+  the `Twitter` class to return a `ZendService\Twitter\Response` instance
+  instead of a zend-http response instance. This allows auto-parsing of the
+  returned JSON response, as well as access to rate limit information.
 
 ### Deprecated
 
@@ -22,8 +70,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Removed
 
-- [#31](https://github.com/zendframework/ZendService_Twitter/pull/31) removes
-  support for PHP versions less than 5.6.
+- [#39](https://github.com/zendframework/ZendService_Twitter/pull/39) removes
+  support for PHP versions less than 7.1.
 
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     },
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.1",
         "zendframework/zend-feed": "^2.7",
         "zendframework/zend-http": "^2.5.4",
         "zendframework/zend-json": "^2.6.1 || ^3.0",
@@ -23,12 +23,22 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^2.6.2",
-        "phpunit/phpunit": "^4.8 || ^5.0"
+        "phpunit/phpunit": "^6.0.8"
     },
     "extra": {
         "branch-alias": {
             "dev-master": "2.0.x-dev",
             "dev-develop": "2.1.x-dev"
         }
+    },
+    "scripts": {
+        "check": [
+            "@cs-check",
+            "@test"
+        ],
+        "cs-check": "phpcs",
+        "cs-fix": "phpcbf",
+        "test": "phpunit --colors=always",
+        "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,47 +4,177 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "3c6b883f32571eaba8e338ff0fa43442",
-    "content-hash": "56dea0d15bd10076815f41e266466629",
+    "content-hash": "77dbd7cc3e3192bbf57f7e16fd5e841e",
     "packages": [
         {
-            "name": "zendframework/zend-config",
-            "version": "2.5.1",
+            "name": "container-interop/container-interop",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/zendframework/zend-config.git",
-                "reference": "ec49b1df1bdd9772df09dc2f612fbfc279bf4c27"
+                "url": "https://github.com/container-interop/container-interop.git",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-config/zipball/ec49b1df1bdd9772df09dc2f612fbfc279bf4c27",
-                "reference": "ec49b1df1bdd9772df09dc2f612fbfc279bf4c27",
+                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.23",
-                "zendframework/zend-stdlib": "~2.5"
+                "psr/container": "^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Container\\": "src/Interop/Container/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
+            "homepage": "https://github.com/container-interop/container-interop",
+            "time": "2017-02-14T19:40:03+00:00"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v2.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "634bae8e911eefa89c1abfbf1b66da679ac8f54d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/634bae8e911eefa89c1abfbf1b66da679ac8f54d",
+                "reference": "634bae8e911eefa89c1abfbf1b66da679ac8f54d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.0"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "~4.0",
-                "zendframework/zend-filter": "~2.5",
-                "zendframework/zend-i18n": "~2.5",
-                "zendframework/zend-json": "~2.5",
-                "zendframework/zend-mvc": "~2.5",
-                "zendframework/zend-servicemanager": "~2.5"
+                "phpunit/phpunit": "4.*|5.*"
             },
             "suggest": {
-                "zendframework/zend-filter": "Zend\\Filter component",
-                "zendframework/zend-i18n": "Zend\\I18n component",
-                "zendframework/zend-json": "Zend\\Json to use the Json reader or writer classes",
-                "zendframework/zend-servicemanager": "Zend\\ServiceManager for use with the Config Factory to retrieve reader and writer instances"
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/random.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "pseudorandom",
+                "random"
+            ],
+            "time": "2017-03-13T16:27:32+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5-dev",
-                    "dev-develop": "2.6-dev"
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "zendframework/zend-config",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-config.git",
+                "reference": "a12e4a592bf66d9629b84960e268f3752e53abe4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-config/zipball/a12e4a592bf66d9629b84960e268f3752e53abe4",
+                "reference": "a12e4a592bf66d9629b84960e268f3752e53abe4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^5.6 || ^7.0",
+                "psr/container": "^1.0",
+                "zendframework/zend-stdlib": "^2.7.7 || ^3.1"
+            },
+            "conflict": {
+                "container-interop/container-interop": "<1.2.0"
+            },
+            "require-dev": {
+                "malukenho/docheader": "^0.1.5",
+                "phpunit/phpunit": "^5.7 || ^6.0",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-filter": "^2.7.1",
+                "zendframework/zend-i18n": "^2.7.3",
+                "zendframework/zend-servicemanager": "^2.7.8 || ^3.2.1"
+            },
+            "suggest": {
+                "zendframework/zend-filter": "^2.7.1; install if you want to use the Filter processor",
+                "zendframework/zend-i18n": "^2.7.3; install if you want to use the Translator processor",
+                "zendframework/zend-servicemanager": "^2.7.8 || ^3.2.1; if you need an extensible plugin manager for use with the Config Factory"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev",
+                    "dev-develop": "3.2-dev"
                 }
             },
             "autoload": {
@@ -62,41 +192,41 @@
                 "config",
                 "zf2"
             ],
-            "time": "2015-06-03 15:32:00"
+            "time": "2017-02-22T14:31:10+00:00"
         },
         {
             "name": "zendframework/zend-crypt",
-            "version": "2.5.1",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-crypt.git",
-                "reference": "15537e8e438a98923f05c40c45c162342ea8235a"
+                "reference": "514cef5556bac069e36c2cbded40e529b86bb3f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-crypt/zipball/15537e8e438a98923f05c40c45c162342ea8235a",
-                "reference": "15537e8e438a98923f05c40c45c162342ea8235a",
+                "url": "https://api.github.com/repos/zendframework/zend-crypt/zipball/514cef5556bac069e36c2cbded40e529b86bb3f2",
+                "reference": "514cef5556bac069e36c2cbded40e529b86bb3f2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.23",
-                "zendframework/zend-math": "~2.5",
-                "zendframework/zend-servicemanager": "~2.5",
-                "zendframework/zend-stdlib": "~2.5"
+                "container-interop/container-interop": "~1.0",
+                "ext-mbstring": "*",
+                "php": "^5.6 || ^7.0",
+                "zendframework/zend-math": "^3.0",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "~4.0",
-                "zendframework/zend-config": "~2.5"
+                "phpunit/phpunit": "^5.6.7",
+                "squizlabs/php_codesniffer": "^2.3.1"
             },
             "suggest": {
-                "ext-mcrypt": "Required for most features of Zend\\Crypt"
+                "ext-openssl": "Required for most features of Zend\\Crypt"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5-dev",
-                    "dev-develop": "2.6-dev"
+                    "dev-master": "3.1-dev",
+                    "dev-develop": "3.2-dev"
                 }
             },
             "autoload": {
@@ -113,24 +243,24 @@
                 "crypt",
                 "zf2"
             ],
-            "time": "2015-06-03 15:32:00"
+            "time": "2017-07-17T15:46:00+00:00"
         },
         {
             "name": "zendframework/zend-escaper",
-            "version": "2.5.0",
+            "version": "2.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-escaper.git",
-                "reference": "a4b227d8a477f4e7e9073f8e0a7ae7dbd3104a73"
+                "reference": "2dcd14b61a72d8b8e27d579c6344e12c26141d4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-escaper/zipball/a4b227d8a477f4e7e9073f8e0a7ae7dbd3104a73",
-                "reference": "a4b227d8a477f4e7e9073f8e0a7ae7dbd3104a73",
+                "url": "https://api.github.com/repos/zendframework/zend-escaper/zipball/2dcd14b61a72d8b8e27d579c6344e12c26141d4e",
+                "reference": "2dcd14b61a72d8b8e27d579c6344e12c26141d4e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.23"
+                "php": ">=5.5"
             },
             "require-dev": {
                 "fabpot/php-cs-fixer": "1.7.*",
@@ -157,36 +287,36 @@
                 "escaper",
                 "zf2"
             ],
-            "time": "2015-06-03 14:05:37"
+            "time": "2016-06-30T19:48:38+00:00"
         },
         {
             "name": "zendframework/zend-feed",
-            "version": "2.7.0",
+            "version": "2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-feed.git",
-                "reference": "12b328d382aa5200f1de53d4147033b885776b67"
+                "reference": "94579e805dd108683209fe14b3b5d4276de3de6e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-feed/zipball/12b328d382aa5200f1de53d4147033b885776b67",
-                "reference": "12b328d382aa5200f1de53d4147033b885776b67",
+                "url": "https://api.github.com/repos/zendframework/zend-feed/zipball/94579e805dd108683209fe14b3b5d4276de3de6e",
+                "reference": "94579e805dd108683209fe14b3b5d4276de3de6e",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0",
+                "php": "^5.6 || ^7.0",
                 "zendframework/zend-escaper": "^2.5",
-                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+                "zendframework/zend-stdlib": "^2.7 || ^3.1"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "~4.0",
+                "phpunit/phpunit": "^6.0.8 || ^5.7.15",
                 "psr/http-message": "^1.0",
-                "zendframework/zend-cache": "^2.5",
-                "zendframework/zend-db": "^2.5",
-                "zendframework/zend-http": "^2.5",
+                "zendframework/zend-cache": "^2.6",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-db": "^2.7",
+                "zendframework/zend-http": "^2.5.4",
                 "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
-                "zendframework/zend-validator": "^2.5"
+                "zendframework/zend-validator": "^2.6"
             },
             "suggest": {
                 "psr/http-message": "PSR-7 ^1.0, if you wish to use Zend\\Feed\\Reader\\Http\\Psr7ResponseDecorator",
@@ -199,8 +329,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev",
-                    "dev-develop": "2.8-dev"
+                    "dev-master": "2.8-dev",
+                    "dev-develop": "2.9-dev"
                 }
             },
             "autoload": {
@@ -218,20 +348,20 @@
                 "feed",
                 "zf2"
             ],
-            "time": "2016-02-11 18:54:29"
+            "time": "2017-04-01T15:03:14+00:00"
         },
         {
             "name": "zendframework/zend-http",
-            "version": "2.5.4",
+            "version": "2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-http.git",
-                "reference": "7b920b4ec34b5ee58f76eb4e8c408b083121953c"
+                "reference": "09f4d279f46d86be63171ff62ee0f79eca878678"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-http/zipball/7b920b4ec34b5ee58f76eb4e8c408b083121953c",
-                "reference": "7b920b4ec34b5ee58f76eb4e8c408b083121953c",
+                "url": "https://api.github.com/repos/zendframework/zend-http/zipball/09f4d279f46d86be63171ff62ee0f79eca878678",
+                "reference": "09f4d279f46d86be63171ff62ee0f79eca878678",
                 "shasum": ""
             },
             "require": {
@@ -242,15 +372,15 @@
                 "zendframework/zend-validator": "^2.5"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
                 "phpunit/phpunit": "^4.0",
+                "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-config": "^2.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5-dev",
-                    "dev-develop": "2.6-dev"
+                    "dev-master": "2.6-dev",
+                    "dev-develop": "2.7-dev"
                 }
             },
             "autoload": {
@@ -268,94 +398,36 @@
                 "http",
                 "zf2"
             ],
-            "time": "2016-02-04 20:36:48"
-        },
-        {
-            "name": "zendframework/zend-hydrator",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/zendframework/zend-hydrator.git",
-                "reference": "22652e1661a5a10b3f564cf7824a2206cf5a4a65"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-hydrator/zipball/22652e1661a5a10b3f564cf7824a2206cf5a4a65",
-                "reference": "22652e1661a5a10b3f564cf7824a2206cf5a4a65",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5 || ^7.0",
-                "zendframework/zend-stdlib": "^2.7 || ^3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "^2.0@dev",
-                "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
-                "zendframework/zend-filter": "^2.6",
-                "zendframework/zend-inputfilter": "^2.6",
-                "zendframework/zend-serializer": "^2.6.1",
-                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3"
-            },
-            "suggest": {
-                "zendframework/zend-eventmanager": "^2.6.2 || ^3.0, to support aggregate hydrator usage",
-                "zendframework/zend-filter": "^2.6, to support naming strategy hydrator usage",
-                "zendframework/zend-serializer": "^2.6.1, to use the SerializableStrategy",
-                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3, to support hydrator plugin manager usage"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-release-1.0": "1.0-dev",
-                    "dev-release-1.1": "1.1-dev",
-                    "dev-master": "2.0-dev",
-                    "dev-develop": "2.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Zend\\Hydrator\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "homepage": "https://github.com/zendframework/zend-hydrator",
-            "keywords": [
-                "hydrator",
-                "zf2"
-            ],
-            "time": "2016-02-18 22:38:26"
+            "time": "2017-01-31T14:41:02+00:00"
         },
         {
             "name": "zendframework/zend-i18n",
-            "version": "2.5.1",
+            "version": "2.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-i18n.git",
-                "reference": "509271eb7947e4aabebfc376104179cffea42696"
+                "reference": "d3431e29cc00c2a1c6704e601d4371dbf24f6a31"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-i18n/zipball/509271eb7947e4aabebfc376104179cffea42696",
-                "reference": "509271eb7947e4aabebfc376104179cffea42696",
+                "url": "https://api.github.com/repos/zendframework/zend-i18n/zipball/d3431e29cc00c2a1c6704e601d4371dbf24f6a31",
+                "reference": "d3431e29cc00c2a1c6704e601d4371dbf24f6a31",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.23",
-                "zendframework/zend-stdlib": "~2.5"
+                "php": "^7.0 || ^5.6",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "~4.0",
-                "zendframework/zend-cache": "~2.5",
-                "zendframework/zend-config": "~2.5",
-                "zendframework/zend-eventmanager": "~2.5",
-                "zendframework/zend-filter": "~2.5",
-                "zendframework/zend-servicemanager": "~2.5",
-                "zendframework/zend-validator": "~2.5",
-                "zendframework/zend-view": "~2.5"
+                "phpunit/phpunit": "^6.0.8 || ^5.7.15",
+                "zendframework/zend-cache": "^2.6.1",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-config": "^2.6",
+                "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
+                "zendframework/zend-filter": "^2.6.1",
+                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+                "zendframework/zend-validator": "^2.6",
+                "zendframework/zend-view": "^2.6.3"
             },
             "suggest": {
                 "ext-intl": "Required for most features of Zend\\I18n; included in default builds of PHP",
@@ -363,7 +435,7 @@
                 "zendframework/zend-config": "Zend\\Config component",
                 "zendframework/zend-eventmanager": "You should install this package to use the events in the translator",
                 "zendframework/zend-filter": "You should install this package to use the provided filters",
-                "zendframework/zend-resources": "Translation resources",
+                "zendframework/zend-i18n-resources": "Translation resources",
                 "zendframework/zend-servicemanager": "Zend\\ServiceManager component",
                 "zendframework/zend-validator": "You should install this package to use the provided validators",
                 "zendframework/zend-view": "You should install this package to use the provided view helpers"
@@ -371,8 +443,12 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5-dev",
-                    "dev-develop": "2.6-dev"
+                    "dev-master": "2.7-dev",
+                    "dev-develop": "2.8-dev"
+                },
+                "zf": {
+                    "component": "Zend\\I18n",
+                    "config-provider": "Zend\\I18n\\ConfigProvider"
                 }
             },
             "autoload": {
@@ -389,44 +465,39 @@
                 "i18n",
                 "zf2"
             ],
-            "time": "2015-06-03 15:32:01"
+            "time": "2017-05-17T17:00:12+00:00"
         },
         {
             "name": "zendframework/zend-json",
-            "version": "2.6.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-json.git",
-                "reference": "4c8705dbe4ad7d7e51b2876c5b9eea0ef916ba28"
+                "reference": "f42a1588e75c2a3e338cd94c37906231e616daab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-json/zipball/4c8705dbe4ad7d7e51b2876c5b9eea0ef916ba28",
-                "reference": "4c8705dbe4ad7d7e51b2876c5b9eea0ef916ba28",
+                "url": "https://api.github.com/repos/zendframework/zend-json/zipball/f42a1588e75c2a3e338cd94c37906231e616daab",
+                "reference": "f42a1588e75c2a3e338cd94c37906231e616daab",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.5 || ^7.0"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
                 "phpunit/phpunit": "~4.0",
-                "zendframework/zend-http": "^2.5.4",
-                "zendframework/zend-server": "^2.6.1",
-                "zendframework/zend-stdlib": "^2.5 || ^3.0",
-                "zendframework/zendxml": "^1.0.2"
+                "squizlabs/php_codesniffer": "^2.3",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
             },
             "suggest": {
-                "zendframework/zend-http": "Zend\\Http component, required to use Zend\\Json\\Server",
-                "zendframework/zend-server": "Zend\\Server component, required to use Zend\\Json\\Server",
-                "zendframework/zend-stdlib": "Zend\\Stdlib component, for use with caching Zend\\Json\\Server responses",
-                "zendframework/zendxml": "To support Zend\\Json\\Json::fromXml() usage"
+                "zendframework/zend-json-server": "For implementing JSON-RPC servers",
+                "zendframework/zend-xml2json": "For converting XML documents to JSON"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev",
-                    "dev-develop": "2.7-dev"
+                    "dev-master": "3.0-dev",
+                    "dev-develop": "3.1-dev"
                 }
             },
             "autoload": {
@@ -444,11 +515,11 @@
                 "json",
                 "zf2"
             ],
-            "time": "2016-02-04 21:20:26"
+            "time": "2016-04-01T02:34:00+00:00"
         },
         {
             "name": "zendframework/zend-loader",
-            "version": "2.5.0",
+            "version": "2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-loader.git",
@@ -488,42 +559,40 @@
                 "loader",
                 "zf2"
             ],
-            "time": "2015-06-03 14:05:47"
+            "time": "2015-06-03T14:05:47+00:00"
         },
         {
             "name": "zendframework/zend-math",
-            "version": "2.5.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-math.git",
-                "reference": "c83fafe02541d5e437e36eb737b912b8d03f222f"
+                "reference": "fda3b4e6c3bb15c35adc6db38b2eacabaa243e65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-math/zipball/c83fafe02541d5e437e36eb737b912b8d03f222f",
-                "reference": "c83fafe02541d5e437e36eb737b912b8d03f222f",
+                "url": "https://api.github.com/repos/zendframework/zend-math/zipball/fda3b4e6c3bb15c35adc6db38b2eacabaa243e65",
+                "reference": "fda3b4e6c3bb15c35adc6db38b2eacabaa243e65",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.23"
+                "ext-mbstring": "*",
+                "paragonie/random_compat": "^2.0.2",
+                "php": "^5.5 || ^7.0"
             },
             "require-dev": {
                 "fabpot/php-cs-fixer": "1.7.*",
-                "ircmaxell/random-lib": "~1.1",
-                "phpunit/phpunit": "~4.0",
-                "zendframework/zend-servicemanager": "~2.5.0"
+                "phpunit/phpunit": "~4.0"
             },
             "suggest": {
                 "ext-bcmath": "If using the bcmath functionality",
-                "ext-gmp": "If using the gmp functionality",
-                "ircmaxell/random-lib": "Fallback random byte generator for Zend\\Math\\Rand if OpenSSL/Mcrypt extensions are unavailable",
-                "zendframework/zend-servicemanager": ">= current version, if using the BigInteger::factory functionality"
+                "ext-gmp": "If using the gmp functionality"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5-dev",
-                    "dev-develop": "2.6-dev"
+                    "dev-master": "3.0-dev",
+                    "dev-develop": "3.1-dev"
                 }
             },
             "autoload": {
@@ -540,99 +609,35 @@
                 "math",
                 "zf2"
             ],
-            "time": "2015-06-03 14:05:49"
-        },
-        {
-            "name": "zendframework/zend-servicemanager",
-            "version": "2.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/zendframework/zend-servicemanager.git",
-                "reference": "72cae675ff4599dfa0b815a508d3f0093036cfa6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-servicemanager/zipball/72cae675ff4599dfa0b815a508d3f0093036cfa6",
-                "reference": "72cae675ff4599dfa0b815a508d3f0093036cfa6",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.23"
-            },
-            "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "~4.0",
-                "zendframework/zend-di": "~2.5.0",
-                "zendframework/zend-mvc": "~2.5.0"
-            },
-            "suggest": {
-                "ocramius/proxy-manager": "ProxyManager 0.5.* to handle lazy initialization of services",
-                "zendframework/zend-di": "Zend\\Di component"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.5-dev",
-                    "dev-develop": "2.6-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Zend\\ServiceManager\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "homepage": "https://github.com/zendframework/zend-servicemanager",
-            "keywords": [
-                "servicemanager",
-                "zf2"
-            ],
-            "time": "2015-06-03 14:05:56"
+            "time": "2016-04-28T17:37:42+00:00"
         },
         {
             "name": "zendframework/zend-stdlib",
-            "version": "2.7.7",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-stdlib.git",
-                "reference": "0e44eb46788f65e09e077eb7f44d2659143bcc1f"
+                "reference": "debedcfc373a293f9250cc9aa03cf121428c8e78"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/0e44eb46788f65e09e077eb7f44d2659143bcc1f",
-                "reference": "0e44eb46788f65e09e077eb7f44d2659143bcc1f",
+                "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/debedcfc373a293f9250cc9aa03cf121428c8e78",
+                "reference": "debedcfc373a293f9250cc9aa03cf121428c8e78",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0",
-                "zendframework/zend-hydrator": "~1.1"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
                 "athletic/athletic": "~0.1",
-                "fabpot/php-cs-fixer": "1.7.*",
                 "phpunit/phpunit": "~4.0",
-                "zendframework/zend-config": "~2.5",
-                "zendframework/zend-eventmanager": "~2.5",
-                "zendframework/zend-filter": "~2.5",
-                "zendframework/zend-inputfilter": "~2.5",
-                "zendframework/zend-serializer": "~2.5",
-                "zendframework/zend-servicemanager": "~2.5"
-            },
-            "suggest": {
-                "zendframework/zend-eventmanager": "To support aggregate hydrator usage",
-                "zendframework/zend-filter": "To support naming strategy hydrator usage",
-                "zendframework/zend-serializer": "Zend\\Serializer component",
-                "zendframework/zend-servicemanager": "To support hydrator plugin manager usage"
+                "squizlabs/php_codesniffer": "^2.6.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-release-2.7": "2.7-dev",
-                    "dev-master": "3.0-dev",
-                    "dev-develop": "3.1-dev"
+                    "dev-master": "3.1-dev",
+                    "dev-develop": "3.2-dev"
                 }
             },
             "autoload": {
@@ -649,7 +654,7 @@
                 "stdlib",
                 "zf2"
             ],
-            "time": "2016-04-12 21:17:31"
+            "time": "2016-09-13T14:38:50+00:00"
         },
         {
             "name": "zendframework/zend-uri",
@@ -696,55 +701,60 @@
                 "uri",
                 "zf2"
             ],
-            "time": "2016-02-17 22:38:51"
+            "time": "2016-02-17T22:38:51+00:00"
         },
         {
             "name": "zendframework/zend-validator",
-            "version": "2.5.1",
+            "version": "2.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-validator.git",
-                "reference": "f2c1a1fc786ff4533003cb7fac477495dc007120"
+                "reference": "a58dbe8463b93de0d650e296d56cb7da4a129ff3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-validator/zipball/f2c1a1fc786ff4533003cb7fac477495dc007120",
-                "reference": "f2c1a1fc786ff4533003cb7fac477495dc007120",
+                "url": "https://api.github.com/repos/zendframework/zend-validator/zipball/a58dbe8463b93de0d650e296d56cb7da4a129ff3",
+                "reference": "a58dbe8463b93de0d650e296d56cb7da4a129ff3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.23",
-                "zendframework/zend-stdlib": "~2.5"
+                "container-interop/container-interop": "^1.1",
+                "php": "^5.6 || ^7.0",
+                "zendframework/zend-stdlib": "^2.7.6 || ^3.1"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "~4.0",
-                "zendframework/zend-cache": "~2.5",
-                "zendframework/zend-config": "~2.5",
-                "zendframework/zend-db": "~2.5",
-                "zendframework/zend-filter": "~2.5",
-                "zendframework/zend-http": "~2.5",
-                "zendframework/zend-i18n": "~2.5",
-                "zendframework/zend-math": "~2.5",
-                "zendframework/zend-servicemanager": "~2.5",
-                "zendframework/zend-session": "~2.5",
-                "zendframework/zend-uri": "~2.5"
+                "phpunit/phpunit": "^6.0.8 || ^5.7.15",
+                "zendframework/zend-cache": "^2.6.1",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-config": "^2.6",
+                "zendframework/zend-db": "^2.7",
+                "zendframework/zend-filter": "^2.6",
+                "zendframework/zend-http": "^2.5.4",
+                "zendframework/zend-i18n": "^2.6",
+                "zendframework/zend-math": "^2.6",
+                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+                "zendframework/zend-session": "^2.6.2",
+                "zendframework/zend-uri": "^2.5"
             },
             "suggest": {
-                "zendframework/zend-db": "Zend\\Db component",
+                "zendframework/zend-db": "Zend\\Db component, required by the (No)RecordExists validator",
                 "zendframework/zend-filter": "Zend\\Filter component, required by the Digits validator",
-                "zendframework/zend-i18n": "Zend\\I18n component to allow translation of validation error messages as well as to use the various Date validators",
-                "zendframework/zend-math": "Zend\\Math component",
-                "zendframework/zend-resources": "Translations of validator messages",
+                "zendframework/zend-i18n": "Zend\\I18n component to allow translation of validation error messages",
+                "zendframework/zend-i18n-resources": "Translations of validator messages",
+                "zendframework/zend-math": "Zend\\Math component, required by the Csrf validator",
                 "zendframework/zend-servicemanager": "Zend\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
-                "zendframework/zend-session": "Zend\\Session component",
+                "zendframework/zend-session": "Zend\\Session component, required by the Csrf validator",
                 "zendframework/zend-uri": "Zend\\Uri component, required by the Uri and Sitemap\\Loc validators"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5-dev",
-                    "dev-develop": "2.6-dev"
+                    "dev-master": "2.9-dev",
+                    "dev-develop": "2.10-dev"
+                },
+                "zf": {
+                    "component": "Zend\\Validator",
+                    "config-provider": "Zend\\Validator\\ConfigProvider"
                 }
             },
             "autoload": {
@@ -762,7 +772,7 @@
                 "validator",
                 "zf2"
             ],
-            "time": "2015-06-03 15:32:03"
+            "time": "2017-07-20T16:44:59+00:00"
         },
         {
             "name": "zendframework/zendoauth",
@@ -809,98 +819,43 @@
                 "oauth",
                 "zf2"
             ],
-            "time": "2014-04-09 01:02:18"
+            "time": "2014-04-09T01:02:18+00:00"
         }
     ],
     "packages-dev": [
         {
-            "name": "dflydev/markdown",
-            "version": "v1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/dflydev/dflydev-markdown.git",
-                "reference": "76501a808522dbe40a5a71d272bd08d54cbae03d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/dflydev/dflydev-markdown/zipball/76501a808522dbe40a5a71d272bd08d54cbae03d",
-                "reference": "76501a808522dbe40a5a71d272bd08d54cbae03d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "dflydev\\markdown": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "New BSD License"
-            ],
-            "authors": [
-                {
-                    "name": "Dragonfly Development Inc.",
-                    "email": "info@dflydev.com",
-                    "homepage": "http://dflydev.com"
-                },
-                {
-                    "name": "Beau Simensen",
-                    "email": "beau@dflydev.com",
-                    "homepage": "http://beausimensen.com"
-                },
-                {
-                    "name": "Michel Fortin",
-                    "homepage": "http://michelf.com"
-                },
-                {
-                    "name": "John Gruber",
-                    "homepage": "http://daringfireball.net"
-                }
-            ],
-            "description": "PHP Markdown & Extra",
-            "homepage": "http://github.com/dflydev/dflydev-markdown",
-            "keywords": [
-                "markdown"
-            ],
-            "abandoned": "michelf/php-markdown",
-            "time": "2012-01-02 23:11:32"
-        },
-        {
             "name": "doctrine/instantiator",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "26404e0c90565b614ee76b988b9bc8790d77f590"
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/26404e0c90565b614ee76b988b9bc8790d77f590",
-                "reference": "26404e0c90565b614ee76b988b9bc8790d77f590",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
                 "shasum": ""
             },
             "require": {
-                "php": "~5.3"
+                "php": "^7.1"
             },
             "require-dev": {
                 "athletic/athletic": "~0.1.8",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "2.0.*@ALPHA"
+                "phpunit/phpunit": "^6.2.3",
+                "squizlabs/php_codesniffer": "^3.0.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Doctrine\\Instantiator\\": "src"
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -920,38 +875,234 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2014-08-25 15:09:25"
+            "time": "2017-07-22T11:58:36+00:00"
         },
         {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "2.0.0",
+            "name": "myclabs/deep-copy",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "66ae84e9d7c8ea85c979cb65977bd8e608baf0c5"
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/66ae84e9d7c8ea85c979cb65977bd8e608baf0c5",
-                "reference": "66ae84e9d7c8ea85c979cb65977bd8e608baf0c5",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/8e6e04167378abf1ddb4d3522d8755c5fd90d102",
+                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102",
                 "shasum": ""
             },
             "require": {
-                "dflydev/markdown": "1.0.*",
-                "php": ">=5.3.3"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "3.7.*@stable"
+                "doctrine/collections": "1.*",
+                "phpunit/phpunit": "~4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "homepage": "https://github.com/myclabs/DeepCopy",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2017-04-12T18:52:22+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^1.0.1",
+                "php": "^5.6 || ^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "phpDocumentor": [
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2017-03-05T18:14:27+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2017-03-05T17:38:23+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2015-12-27T11:43:31+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "183824db76118b9dddffc7e522b91fa175f75119"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/183824db76118b9dddffc7e522b91fa175f75119",
+                "reference": "183824db76118b9dddffc7e522b91fa175f75119",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "phpdocumentor/reflection-common": "^1.0@dev",
+                "phpdocumentor/type-resolver": "^0.3.0",
+                "webmozart/assert": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^4.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
                         "src/"
                     ]
                 }
@@ -963,36 +1114,88 @@
             "authors": [
                 {
                     "name": "Mike van Riel",
-                    "email": "mike.vanriel@naenius.com"
+                    "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2013-08-07 11:04:22"
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2017-08-04T20:55:59+00:00"
         },
         {
-            "name": "phpspec/prophecy",
-            "version": "v1.3.1",
+            "name": "phpdocumentor/type-resolver",
+            "version": "0.3.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "9ca52329bcdd1500de24427542577ebf3fc2f1c9"
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "fb3933512008d8162b3cdf9e18dba9309b7c3773"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/9ca52329bcdd1500de24427542577ebf3fc2f1c9",
-                "reference": "9ca52329bcdd1500de24427542577ebf3fc2f1c9",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/fb3933512008d8162b3cdf9e18dba9309b7c3773",
+                "reference": "fb3933512008d8162b3cdf9e18dba9309b7c3773",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "~1.0,>=1.0.2",
-                "phpdocumentor/reflection-docblock": "~2.0"
+                "php": "^5.5 || ^7.0",
+                "phpdocumentor/reflection-common": "^1.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "~2.0"
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "time": "2017-06-03T08:32:36+00:00"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "v1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/93d39f1f7f9326d746203c7c056f300f7f126073",
+                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
+                "sebastian/comparator": "^1.1|^2.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^2.5|^3.2",
+                "phpunit/phpunit": "^4.8 || ^5.6.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
                 }
             },
             "autoload": {
@@ -1016,7 +1219,7 @@
                 }
             ],
             "description": "Highly opinionated mocking framework for PHP 5.3+",
-            "homepage": "http://phpspec.org",
+            "homepage": "https://github.com/phpspec/prophecy",
             "keywords": [
                 "Double",
                 "Dummy",
@@ -1025,43 +1228,45 @@
                 "spy",
                 "stub"
             ],
-            "time": "2014-11-17 16:23:49"
+            "time": "2017-03-02T20:05:34+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.1.0",
+            "version": "5.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "ba315f46873fd6e86fdb98685a1a900e7379c886"
+                "reference": "8ed1902a57849e117b5651fc1a5c48110946c06b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ba315f46873fd6e86fdb98685a1a900e7379c886",
-                "reference": "ba315f46873fd6e86fdb98685a1a900e7379c886",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/8ed1902a57849e117b5651fc1a5c48110946c06b",
+                "reference": "8ed1902a57849e117b5651fc1a5c48110946c06b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "phpunit/php-file-iterator": "~1.3",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "~1.3",
-                "sebastian/environment": "~1.0",
-                "sebastian/version": "~1.0"
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0",
+                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^1.4.11 || ^2.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^3.0",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "~4"
+                "ext-xdebug": "^2.5",
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
-                "ext-dom": "*",
-                "ext-xdebug": ">=2.2.1",
-                "ext-xmlwriter": "*"
+                "ext-xdebug": "^2.5.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1.x-dev"
+                    "dev-master": "5.2.x-dev"
                 }
             },
             "autoload": {
@@ -1087,20 +1292,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-05-30 12:58:40"
+            "time": "2017-08-03T12:40:43+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.0",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "a923bb15680d0089e2316f7a4af8f437046e96bb"
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a923bb15680d0089e2316f7a4af8f437046e96bb",
-                "reference": "a923bb15680d0089e2316f7a4af8f437046e96bb",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
                 "shasum": ""
             },
             "require": {
@@ -1134,20 +1339,20 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-04-02 05:19:05"
+            "time": "2016-10-03T07:40:28+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "206dfefc0ffe9cebf65c413e3d0e809c82fbf00a"
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/206dfefc0ffe9cebf65c413e3d0e809c82fbf00a",
-                "reference": "206dfefc0ffe9cebf65c413e3d0e809c82fbf00a",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
                 "shasum": ""
             },
             "require": {
@@ -1156,20 +1361,17 @@
             "type": "library",
             "autoload": {
                 "classmap": [
-                    "Text/"
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
             "license": [
                 "BSD-3-Clause"
             ],
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1178,26 +1380,34 @@
             "keywords": [
                 "template"
             ],
-            "time": "2014-01-30 17:20:04"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.6",
+            "version": "1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "83fe1bdc5d47658b727595c14da140da92b3d66d"
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/83fe1bdc5d47658b727595c14da140da92b3d66d",
-                "reference": "83fe1bdc5d47658b727595c14da140da92b3d66d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -1219,33 +1429,33 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2015-06-13 07:35:30"
+            "time": "2017-02-26T11:10:40+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.3.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "f8d5d08c56de5cfd592b3340424a81733259a876"
+                "reference": "ecb0b2cdaa0add708fe6f329ef65ae0c5225130b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/f8d5d08c56de5cfd592b3340424a81733259a876",
-                "reference": "f8d5d08c56de5cfd592b3340424a81733259a876",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/ecb0b2cdaa0add708fe6f329ef65ae0c5225130b",
+                "reference": "ecb0b2cdaa0add708fe6f329ef65ae0c5225130b",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.2.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1268,45 +1478,57 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2014-08-31 06:12:13"
+            "time": "2017-08-03T14:17:41+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.0",
+            "version": "6.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "283111a903eb9225aedb95e846bef876e006a688"
+                "reference": "9501bab711403a1ab5b8378a8adb4ec3db3debdb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/283111a903eb9225aedb95e846bef876e006a688",
-                "reference": "283111a903eb9225aedb95e846bef876e006a688",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9501bab711403a1ab5b8378a8adb4ec3db3debdb",
+                "reference": "9501bab711403a1ab5b8378a8adb4ec3db3debdb",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-json": "*",
-                "ext-pcre": "*",
-                "ext-reflection": "*",
-                "ext-spl": "*",
-                "php": ">=5.3.3",
-                "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "~2.1",
-                "phpunit/php-file-iterator": "~1.4",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-timer": ">=1.0.6",
-                "phpunit/phpunit-mock-objects": "~2.3",
-                "sebastian/comparator": "~1.1",
-                "sebastian/diff": "~1.2",
-                "sebastian/environment": "~1.3",
-                "sebastian/exporter": "~1.2",
-                "sebastian/global-state": "~1.0",
-                "sebastian/version": "~1.0",
-                "symfony/yaml": "~2.1|~3.0"
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "myclabs/deep-copy": "^1.6.1",
+                "phar-io/manifest": "^1.0.1",
+                "phar-io/version": "^1.0",
+                "php": "^7.0",
+                "phpspec/prophecy": "^1.7",
+                "phpunit/php-code-coverage": "^5.2.2",
+                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^1.0.9",
+                "phpunit/phpunit-mock-objects": "^4.0.3",
+                "sebastian/comparator": "^2.0.2",
+                "sebastian/diff": "^2.0",
+                "sebastian/environment": "^3.1",
+                "sebastian/exporter": "^3.1",
+                "sebastian/global-state": "^2.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^1.0",
+                "sebastian/version": "^2.0.1"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "3.0.2",
+                "phpunit/dbunit": "<3.0"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
             },
             "suggest": {
-                "phpunit/php-invoker": "~1.1"
+                "ext-xdebug": "*",
+                "phpunit/php-invoker": "^1.1"
             },
             "bin": [
                 "phpunit"
@@ -1314,7 +1536,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.8.x-dev"
+                    "dev-master": "6.3.x-dev"
                 }
             },
             "autoload": {
@@ -1340,29 +1562,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-08-07 03:57:43"
+            "time": "2017-08-04T05:20:39+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.0",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "c63d2367247365f688544f0d500af90a11a44c65"
+                "reference": "2f789b59ab89669015ad984afa350c4ec577ade0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/c63d2367247365f688544f0d500af90a11a44c65",
-                "reference": "c63d2367247365f688544f0d500af90a11a44c65",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/2f789b59ab89669015ad984afa350c4ec577ade0",
+                "reference": "2f789b59ab89669015ad984afa350c4ec577ade0",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "~1.0,>=1.0.1",
-                "php": ">=5.3.3",
-                "phpunit/php-text-template": "~1.2"
+                "doctrine/instantiator": "^1.0.5",
+                "php": "^7.0",
+                "phpunit/php-text-template": "^1.2.1",
+                "sebastian/exporter": "^3.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.3"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -1370,7 +1596,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3.x-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
@@ -1395,34 +1621,79 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2014-10-03 05:12:11"
+            "time": "2017-08-03T14:08:16+00:00"
         },
         {
-            "name": "sebastian/comparator",
-            "version": "1.1.0",
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "c484a80f97573ab934e37826dba0135a3301b26a"
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/c484a80f97573ab934e37826dba0135a3301b26a",
-                "reference": "c484a80f97573ab934e37826dba0135a3301b26a",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/diff": "~1.1",
-                "sebastian/exporter": "~1.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.1"
+                "phpunit/phpunit": "^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2017-03-04T06:30:41+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "ae068fede81d06e7bb9bb46a367210a3d3e1fe6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/ae068fede81d06e7bb9bb46a367210a3d3e1fe6a",
+                "reference": "ae068fede81d06e7bb9bb46a367210a3d3e1fe6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "sebastian/diff": "^2.0",
+                "sebastian/exporter": "^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1459,32 +1730,32 @@
                 "compare",
                 "equality"
             ],
-            "time": "2014-11-16 21:32:38"
+            "time": "2017-08-03T07:14:59+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.2.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "5843509fed39dee4b356a306401e9dd1a931fec7"
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/5843509fed39dee4b356a306401e9dd1a931fec7",
-                "reference": "5843509fed39dee4b356a306401e9dd1a931fec7",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1507,36 +1778,36 @@
                 }
             ],
             "description": "Diff implementation",
-            "homepage": "http://www.github.com/sebastianbergmann/diff",
+            "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
                 "diff"
             ],
-            "time": "2014-08-15 10:29:00"
+            "time": "2017-08-03T08:09:46+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "4fe0a44cddd8cc19583a024bdc7374eb2fef0b87"
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/4fe0a44cddd8cc19583a024bdc7374eb2fef0b87",
-                "reference": "4fe0a44cddd8cc19583a024bdc7374eb2fef0b87",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -1561,33 +1832,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2015-07-26 06:42:57"
+            "time": "2017-07-01T08:51:00+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "84839970d05254c73cde183a721c7af13aede943"
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/84839970d05254c73cde183a721c7af13aede943",
-                "reference": "84839970d05254c73cde183a721c7af13aede943",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/recursion-context": "~1.0"
+                "php": "^7.0",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -1627,27 +1899,27 @@
                 "export",
                 "exporter"
             ],
-            "time": "2015-01-27 07:23:06"
+            "time": "2017-04-03T13:19:02+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "1.0.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "c7428acdb62ece0a45e6306f1ae85e1c05b09c01"
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/c7428acdb62ece0a45e6306f1ae85e1c05b09c01",
-                "reference": "c7428acdb62ece0a45e6306f1ae85e1c05b09c01",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -1655,7 +1927,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1678,32 +1950,124 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2014-10-06 09:23:50"
+            "time": "2017-04-27T15:39:26+00:00"
         },
         {
-            "name": "sebastian/recursion-context",
-            "version": "1.0.0",
+            "name": "sebastian/object-enumerator",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "3989662bbb30a29d20d9faa04a846af79b276252"
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/3989662bbb30a29d20d9faa04a846af79b276252",
-                "reference": "3989662bbb30a29d20d9faa04a846af79b276252",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2017-08-03T12:35:26+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2017-03-29T09:07:27+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -1731,23 +2095,73 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-01-24 09:48:32"
+            "time": "2017-03-03T06:23:57+00:00"
         },
         {
-            "name": "sebastian/version",
+            "name": "sebastian/resource-operations",
             "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "16b021aed448b654ae05846e394e057e9a6f04cb"
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/16b021aed448b654ae05846e394e057e9a6f04cb",
-                "reference": "16b021aed448b654ae05846e394e057e9a6f04cb",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=5.6.0"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2015-07-28T20:34:47+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -1766,20 +2180,20 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2013-01-05 14:27:32"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.6.2",
+            "version": "2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "4edb770cb853def6e60c93abb088ad5ac2010c83"
+                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4edb770cb853def6e60c93abb088ad5ac2010c83",
-                "reference": "4edb770cb853def6e60c93abb088ad5ac2010c83",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62",
                 "shasum": ""
             },
             "require": {
@@ -1844,35 +2258,78 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-07-13 23:29:13"
+            "time": "2017-05-22T02:43:20+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "v2.1.0",
-            "target-dir": "Symfony/Component/Yaml",
+            "name": "theseer/tokenizer",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "f18e004fc975707bb4695df1dbbe9b0d8c8b7715"
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/f18e004fc975707bb4695df1dbbe9b0d8c8b7715",
-                "reference": "f18e004fc975707bb4695df1dbbe9b0d8c8b7715",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2017-04-07T12:08:54+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Symfony\\Component\\Yaml": ""
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1881,26 +2338,26 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
                 }
             ],
-            "description": "Symfony Yaml Component",
-            "homepage": "http://symfony.com",
-            "time": "2012-08-22 13:48:41"
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2016-11-23T20:04:58+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],
-    "prefer-stable": true,
-    "prefer-lowest": true,
+    "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": {
-        "php": "^5.6 || ^7.0"
+        "php": "^7.1"
     },
     "platform-dev": []
 }

--- a/library/ZendService/Twitter/Exception/InvalidMediaException.php
+++ b/library/ZendService/Twitter/Exception/InvalidMediaException.php
@@ -5,17 +5,10 @@
  * @license   https://github.com/zendframework/ZendService_Twitter/blob/master/LICENSE.md New BSD License
  */
 
-namespace ZendService\Twitter;
+namespace ZendService\Twitter\Exception;
 
-/**
- * Twitter Video Uploader
- *
- * @author Cal Evans <cal@calevans.com>
- */
-class Video extends Media
+use RuntimeException;
+
+class InvalidMediaException extends RuntimeException implements ExceptionInterface
 {
-    public function __construct(string $imageUrl, string $mediaType = 'video/mp4')
-    {
-        parent::__construct($imageUrl, $mediaType);
-    }
 }

--- a/library/ZendService/Twitter/Exception/MediaUploadException.php
+++ b/library/ZendService/Twitter/Exception/MediaUploadException.php
@@ -5,17 +5,10 @@
  * @license   https://github.com/zendframework/ZendService_Twitter/blob/master/LICENSE.md New BSD License
  */
 
-namespace ZendService\Twitter;
+namespace ZendService\Twitter\Exception;
 
-/**
- * Twitter Video Uploader
- *
- * @author Cal Evans <cal@calevans.com>
- */
-class Video extends Media
+use RuntimeException;
+
+class MediaUploadException extends RuntimeException implements ExceptionInterface
 {
-    public function __construct(string $imageUrl, string $mediaType = 'video/mp4')
-    {
-        parent::__construct($imageUrl, $mediaType);
-    }
 }

--- a/library/ZendService/Twitter/Image.php
+++ b/library/ZendService/Twitter/Image.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace ZendService\Twitter;
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Service
+ */
+
+use Zend\Http\Client as Client;
+use ZendService\Twitter\Response as Response;
+
+/**
+ * Twitter Image Uploader
+ *
+ * @category   Zend
+ * @package    Zend_Service
+ * @subpackage Twitter
+ * @author Cal Evans <cal@calevans.com>
+ */
+class Image extends Media
+{
+
+	public function __construct($image_url = null, $media_type = 'image/jpeg')
+	{
+		parent::__construct($image_url, $media_type);
+	}
+
+}

--- a/library/ZendService/Twitter/Image.php
+++ b/library/ZendService/Twitter/Image.php
@@ -1,32 +1,24 @@
 <?php
-
-namespace ZendService\Twitter;
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Service
+ * @see       https://github.com/zendframework/ZendService_Twitter for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/ZendService_Twitter/blob/master/LICENSE.md New BSD License
  */
 
-use Zend\Http\Client as Client;
-use ZendService\Twitter\Response as Response;
+namespace ZendService\Twitter;
 
 /**
  * Twitter Image Uploader
  *
- * @category   Zend
- * @package    Zend_Service
- * @subpackage Twitter
  * @author Cal Evans <cal@calevans.com>
  */
 class Image extends Media
 {
-
-	public function __construct($image_url = null, $media_type = 'image/jpeg')
-	{
-		parent::__construct($image_url, $media_type);
-	}
-
+    /**
+     * @param $imageUrl
+     */
+    public function __construct(string $imageUrl, string $mediaType = 'image/jpeg')
+    {
+        parent::__construct($imageUrl, $mediaType);
+    }
 }

--- a/library/ZendService/Twitter/Media.php
+++ b/library/ZendService/Twitter/Media.php
@@ -1,0 +1,265 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Service
+ */
+
+namespace ZendService\Twitter;
+
+use Zend\Http\Client as Client;
+use ZendService\Twitter\Response as Response;
+
+
+/**
+ * Twitter Media Uploader base class
+ *
+ * @category   Zend
+ * @package    Zend_Service
+ * @subpackage Twitter
+ * @author Cal Evans <cal@calevans.com>
+ */
+Class Media
+{
+
+    /**
+     * Array of basic data to be stored by this class.
+     *
+     * @var Array
+     */
+    protected $data = [];
+
+    /**
+     * The number of bytes to send to Twitter at one time.
+     * @var Integer
+     */
+    protected $chunkSize = (1024*1024)*4;
+
+    /**
+     * The base URI for this API call
+     *
+     * @var String
+     */
+    protected $baseUri = 'https://upload.twitter.com';
+
+    /**
+     * The API endpoint for all calls.
+     *
+     * @var String
+     */
+    protected $endPoint = '/1.1/media/upload.json';
+
+
+    /**
+     * Constructor
+     *
+     * @param  null|string $image_filename
+     * @param  string $consumer
+     */
+    public function __construct($image_filename = null, $media_type = '')
+    {
+        $this->data['image_filename'] = '';
+        $this->data['media_id']       = 0;
+        $this->data['segment_index']  = 0;
+        $this->data['media_type']     = $media_type;
+
+        if (! is_null($image_filename)) {
+            $this->data['image_filename']=$image_filename;
+        }
+
+    }
+
+
+    /**
+     * Main call into the upload workflow
+     *
+     * @param  Client $httpClient
+     * @return Twitter\Response
+     * @throws \Exception If the file can't be opened.
+     */
+    public function upload(Client $httpClient)
+    {
+        if (! $this->validateFile($this->data['image_filename'])) {
+            throw new \Exception('Failed to open '.$this->data['image_filename']);
+        }
+
+        if (empty($this->data['media_type'])) {
+            throw new \Exception('No Media Type given.');
+        }
+
+        $params = [];
+        $httpClient->setUri($this->baseUri . $this->endPoint);
+        
+        $params['total_bytes'] = filesize($this->data['image_filename']);
+        $params['media_type']  = $this->data['media_type'];
+
+        $response = $this->initUpload($httpClient,$params);
+        $initResponse = $response->toValue();
+
+        if (! $response->isSuccess()) {
+            throw new \Exception('Failed to init the upload with Twitter.');
+        }
+
+        $this->data['media_id'] = $initResponse->media_id;
+
+        $success = $this->appendUpload($httpClient,$params);
+
+        if (! $success) {
+            throw new \Exception('Failed the APPEND stage of the upload.');
+        }
+
+        $response = $this->finalizeUpload($httpClient,$params);
+
+        return $response;
+    }
+
+
+    /**
+     * Initalize the upload with Twitter
+     *
+     * @param Http\Client $httpClient
+     * @params array $params
+     * @return Twitter\Response
+     */
+    protected function initUpload($httpClient, $params)
+    {
+        $payload = ['command'     => 'INIT',
+                    'media_type'  => $params['media_type'],
+                    'total_bytes' => $params['total_bytes']];
+
+        $httpClient->resetParameters();
+        $httpClient->setHeaders(['Content-type' => 'application/x-www-form-urlencoded']);
+        $httpClient->setMethod('POST');
+        $httpClient->setParameterPost($payload);
+        $response = $httpClient->send();
+        return new Response($response);
+    }
+
+
+    /**
+     * Send the chunks of the file to Twitter
+     *
+     * @param Http\Client $httpClient
+     * @params array $params
+     * @return boolean
+     */
+    protected function appendUpload($httpClient, $params)
+    {
+        $payload = ['command'   => 'APPEND',
+                    'media_id' => $this->data['media_id']];
+
+        $fileHandle = fopen($this->data['image_filename'],'rb');
+
+        if (! $fileHandle) {
+            throw new \Exception('Failed to open the file in the APPEND method.');
+        }
+
+        while (! feof($fileHandle)) 
+        {
+            $data = fread($fileHandle, $this->chunkSize);
+
+            $payload['media_data'] = base64_encode($data);
+            $payload['segment_index'] = $this->data['segment_index']++;
+
+            $httpClient->resetParameters();
+            $httpClient->setHeaders(['Content-type' => 'application/x-www-form-urlencoded']);
+            $httpClient->setMethod('POST');
+            $httpClient->setParameterPost($payload);
+
+            $response = $httpClient->send();
+            $appendStatus = $response->isSuccess();
+
+            if (! $appendStatus) {
+                throw new \Exception('Failed uploading segment ' . 
+                                     ($this->data['segment_index']-1) . ' of ' . 
+                                     $this->data['image_filename'] . 
+                                     ". Error Code: ". $response->getStatusCode() . 
+                                     ". Reason: " . $response->getReasonPhrase());
+            }
+
+        }
+
+        fClose($fileHandle);
+
+        return $appendStatus;
+    }
+
+
+    /**
+     * Send the upload finalize to Twitter
+     *
+     * @param Http\Client $httpClient
+     * @params array $params
+     * @return Twitter\Response
+     */
+    protected function finalizeUpload($httpClient,$params)
+    {
+        $payload = ['command'  => 'FINALIZE',
+                    'media_id' => $this->data['media_id']];
+
+        $httpClient->resetParameters();
+        $httpClient->setHeaders(['Content-type' => 'application/x-www-form-urlencoded']);
+        $httpClient->setMethod('POST');
+        $httpClient->setParameterPost($payload);
+        $response = $httpClient->send();
+        
+        return new Response($response);
+    }
+    
+    
+    /**
+     * Validate that the file exists and can be opened.
+     * 
+     * @todo Put a check to make sure the file is local.
+     * @param string $fileName
+     * @return boolean
+     */
+    protected function validateFile($fileName)
+    {
+        $returnValue = false;
+        $returnValue = file_exists($fileName);
+
+        if ($returnValue) {
+            $returnValue = ($handle = fopen($fileName,'rb'));
+
+            if ($returnValue) {
+                fClose($handle);
+            }
+
+        }
+
+        return $returnValue;
+    }
+
+
+    /**
+     * Method overloading
+     *
+     * @param  string $key
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        return isset($this->data[$key])?$this->data[$key]:null;
+    }
+
+
+    /**
+     * Method overloading
+     *
+     * @param string $key
+     * @param mixed $value
+     */
+    public function __set($key, $value)
+    {
+        if (isset($this->data[$key])) {
+            $this->data[$key]= $value;
+        }
+
+        return;
+    }
+
+}

--- a/library/ZendService/Twitter/RateLimit.php
+++ b/library/ZendService/Twitter/RateLimit.php
@@ -1,11 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Service
+ * @see       https://github.com/zendframework/ZendService_Twitter for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/ZendService_Twitter/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendService\Twitter;
@@ -14,7 +11,6 @@ use Zend\Http\Headers as Headers;
 
 /**
  * Representation of the Rate Limit Headers from Twitter.
- *
  */
 class RateLimit
 {
@@ -45,13 +41,13 @@ class RateLimit
         }
 
         $this->limit = $headers->has('x-rate-limit-limit')
-            ? $headers->get('x-rate-limit-limit')->getFieldValue()
+            ? (int) $headers->get('x-rate-limit-limit')->getFieldValue()
             : 0;
         $this->remaining = $headers->has('x-rate-limit-remaining')
-            ? $headers->get('x-rate-limit-remaining')->getFieldValue()
+            ? (int) $headers->get('x-rate-limit-remaining')->getFieldValue()
             : 0;
         $this->reset = $headers->has('x-rate-limit-reset')
-            ? $headers->get('x-rate-limit-reset')->getFieldValue()
+            ? (int) $headers->get('x-rate-limit-reset')->getFieldValue()
             : 0;
     }
 
@@ -62,7 +58,7 @@ class RateLimit
      * @param string $key
      * @return null|int
      */
-    public function __get($key)
+    public function __get($key) : ?int
     {
         return isset($this->$key) ? $this->$key : null;
     }
@@ -73,7 +69,7 @@ class RateLimit
      * @param string $key
      * @return bool
      */
-    public function __isset($key)
+    public function __isset($key) : bool
     {
         return property_exists($this, $key);
     }

--- a/library/ZendService/Twitter/Response.php
+++ b/library/ZendService/Twitter/Response.php
@@ -28,14 +28,6 @@ use Zend\Json\Json;
 class Response
 {
     /**
-     * Empty body content that should not result in response population.
-     */
-    private $emptyBodyContent = [
-        null,
-        '',
-    ];
-
-    /**
      * @var HttpResponse
      */
     protected $httpResponse;
@@ -51,9 +43,17 @@ class Response
     protected $rawBody;
 
     /**
+     * Empty body content that should not result in response population.
+     */
+    private $emptyBodyContent = [
+        null,
+        '',
+    ];
+
+    /**
      * @var RateLimit
      */
-    protected $rateLimit;
+    private $rateLimit;
 
     /**
      * Constructor
@@ -100,7 +100,7 @@ class Response
      *
      * @return bool
      */
-    public function isSuccess()
+    public function isSuccess() : bool
     {
         return $this->httpResponse->isSuccess();
     }
@@ -110,7 +110,7 @@ class Response
      *
      * @return bool
      */
-    public function isError()
+    public function isError() : bool
     {
         return ! $this->httpResponse->isSuccess();
     }
@@ -124,10 +124,9 @@ class Response
      *
      * If the response was successful, an empty array is returned.
      *
-     * @return array
      * @throws Exception\DomainException if unable to detect structure of error response
      */
-    public function getErrors()
+    public function getErrors() : array
     {
         if (! $this->isError()) {
             return [];
@@ -144,10 +143,8 @@ class Response
 
     /**
      * Retrieve the raw response body
-     *
-     * @return string
      */
-    public function getRawResponse()
+    public function getRawResponse() : string
     {
         return $this->rawBody;
     }
@@ -163,11 +160,9 @@ class Response
     }
 
     /**
-     * Retun the RateLimit object
-     *
-     * @return RateLimit
+     * Retun the RateLimit object associated with the response.
      */
-    public function getRateLimit()
+    public function getRateLimit() : RateLimit
     {
         return $this->rateLimit;
     }
@@ -176,10 +171,9 @@ class Response
      * Populates the object with info. This can possibly called from the
      * constructor, or it can be called later.
      *
-     * @param  null|HttpResponse $httpResponse
-     * @return void
+     * @throws Exception\DomainException if an error occurs parsing the response.
      */
-    private function populate(HttpResponse $httpResponse = null)
+    private function populate(HttpResponse $httpResponse = null) : void
     {
         $this->httpResponse = $httpResponse;
         $this->rawBody = $httpResponse->getBody();

--- a/library/ZendService/Twitter/Twitter.php
+++ b/library/ZendService/Twitter/Twitter.php
@@ -483,10 +483,6 @@ class Twitter
             throw new Exception\InvalidArgumentException(
                 'Direct message must contain at least one character'
             );
-        } elseif (140 < $len) {
-            throw new Exception\OutOfRangeException(
-                'Direct message must contain no more than 140 characters'
-            );
         }
 
         $params         = $this->createUserParameter($user, []);

--- a/library/ZendService/Twitter/Twitter.php
+++ b/library/ZendService/Twitter/Twitter.php
@@ -946,7 +946,7 @@ class Twitter
      * @throws Exception\DomainException if unable to decode JSON payload
      * @return Response
      */
-    public function statusesUpdate($status, $inReplyToStatusId = null, $extraAttributes=[])
+    public function statusesUpdate($status, $inReplyToStatusId = null, $extraAttributes = [])
     {
         $this->init();
         $path = 'statuses/update';
@@ -965,10 +965,11 @@ class Twitter
 
         $params = ['status' => $status];
 
-        if (isset($extraAttributes['media_ids']) 
-            and is_array($extraAttributes['media_ids']) 
-            and ! empty($extraAttributes['media_ids'])) {
-            $params['media_ids']=implode(',',$extraAttributes['media_ids']);
+        if (isset($extraAttributes['media_ids'])
+            && is_array($extraAttributes['media_ids'])
+            && ! empty($extraAttributes['media_ids'])
+        ) {
+            $params['media_ids'] = implode(',', $extraAttributes['media_ids']);
         }
 
         $inReplyToStatusId = $this->validInteger($inReplyToStatusId);

--- a/library/ZendService/Twitter/Twitter.php
+++ b/library/ZendService/Twitter/Twitter.php
@@ -946,7 +946,7 @@ class Twitter
      * @throws Exception\DomainException if unable to decode JSON payload
      * @return Response
      */
-    public function statusesUpdate($status, $inReplyToStatusId = null)
+    public function statusesUpdate($status, $inReplyToStatusId = null, $extraAttributes=[])
     {
         $this->init();
         $path = 'statuses/update';
@@ -964,6 +964,13 @@ class Twitter
         }
 
         $params = ['status' => $status];
+
+        if (isset($extraAttributes['media_ids']) 
+            and is_array($extraAttributes['media_ids']) 
+            and ! empty($extraAttributes['media_ids'])) {
+            $params['media_ids']=implode(',',$extraAttributes['media_ids']);
+        }
+
         $inReplyToStatusId = $this->validInteger($inReplyToStatusId);
         if ($inReplyToStatusId) {
             $params['in_reply_to_status_id'] = $inReplyToStatusId;

--- a/library/ZendService/Twitter/Video.php
+++ b/library/ZendService/Twitter/Video.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace ZendService\Twitter;
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Service
+ */
+
+use Zend\Http\Client as Client;
+use ZendService\Twitter\Response as Response;
+
+/**
+ * Twitter Video Uploader
+ *
+ * @category   Zend
+ * @package    Zend_Service
+ * @subpackage Twitter
+ * @author Cal Evans <cal@calevans.com>
+ */
+class Video extends Media
+{
+
+	public function __construct($image_url = null, $media_type = 'video/mp4')
+	{
+		parent::__construct($image_url, $media_type);
+	}
+
+}

--- a/tests/ZendService/Twitter/ImageTest.php
+++ b/tests/ZendService/Twitter/ImageTest.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/ZendService_Twitter for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/ZendService_Twitter/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendServiceTest\Twitter;
+
+use PHPUnit\Framework\TestCase;
+use ZendService\Twitter\Image;
+
+class ImageTest extends TestCase
+{
+    public function testCanBeInstantiatedWithNoMediaTypeAndUsesSaneDefaults()
+    {
+        $image = new Image(__FILE__);
+        $this->assertAttributeEquals(__FILE__, 'imageFilename', $image);
+        $this->assertAttributeEquals('image/jpeg', 'mediaType', $image);
+    }
+
+    public function testCanBeInstantiatedWithFilenameAndMediaType()
+    {
+        $image = new Image(__FILE__, 'text/plain');
+        $this->assertAttributeEquals(__FILE__, 'imageFilename', $image);
+        $this->assertAttributeEquals('text/plain', 'mediaType', $image);
+    }
+}

--- a/tests/ZendService/Twitter/MediaTest.php
+++ b/tests/ZendService/Twitter/MediaTest.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/ZendService_Twitter for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/ZendService_Twitter/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendServiceTest\Twitter;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use ReflectionProperty;
+use Zend\Http\Client as Client;
+use Zend\Http\Response;
+use ZendService\Twitter\Exception;
+use ZendService\Twitter\Media;
+use ZendService\Twitter\Response as TwitterResponse;
+
+class MediaTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->client = $this->prophesize(Client::class);
+    }
+
+    public function testAllowsPassingImageFilenameAndMediaType()
+    {
+        $media = new Media(__FILE__, 'text/plain');
+        $this->assertAttributeSame(__FILE__, 'imageFilename', $media);
+        $this->assertAttributeSame('text/plain', 'mediaType', $media);
+    }
+
+    public function testUploadRaisesExceptionIfNoImageFilenamePresent()
+    {
+        $media = new Media('', 'text/plain');
+        $this->expectException(Exception\InvalidMediaException::class);
+        $this->expectExceptionMessage('Failed to open');
+        $media->upload($this->client->reveal());
+    }
+
+    public function testUploadRaisesExceptionIfNoMediaTypePresent()
+    {
+        $media = new Media(__FILE__, '');
+        $this->expectException(Exception\InvalidMediaException::class);
+        $this->expectExceptionMessage('Invalid Media Type');
+        $media->upload($this->client->reveal());
+    }
+
+    public function testUnsuccessfulUploadInitializationRaisesException()
+    {
+        $this->client->setUri(Media::UPLOAD_BASE_URI)->shouldBeCalled();
+        $this->client->resetParameters()->shouldBeCalled();
+        $this->client->setHeaders([
+            'Content-type' => 'application/x-www-form-urlencoded'
+        ])->shouldBeCalled();
+        $this->client->setMethod('POST')->shouldBeCalled();
+        $this->client->setParameterPost([
+            'command'     => 'INIT',
+            'media_type'  => 'image/png',
+            'total_bytes' => filesize(__FILE__),
+        ])->shouldBeCalled();
+
+        $response = $this->prophesize(Response::class);
+        $response->getBody()->willReturn('{}');
+        $response->getHeaders()->willReturn(null);
+        $response->isSuccess()->willReturn(false);
+
+        $this->client->send()->will([$response, 'reveal']);
+
+        $media = new Media(__FILE__, 'image/png');
+
+        $this->expectException(Exception\MediaUploadException::class);
+        $this->expectExceptionMessage('Failed to initialize Twitter media upload');
+        $media->upload($this->client->reveal());
+    }
+
+    public function testAppendUploadRaisesExceptionIfUnableToOpenFile()
+    {
+        $media = new Media(__FILE__, 'image/png');
+
+        $this->client->setUri(Media::UPLOAD_BASE_URI)->shouldBeCalled();
+        $this->client->resetParameters()->shouldBeCalled();
+        $this->client->setHeaders([
+            'Content-type' => 'application/x-www-form-urlencoded'
+        ])->shouldBeCalled();
+        $this->client->setMethod('POST')->shouldBeCalled();
+        $this->client->setParameterPost([
+            'command'     => 'INIT',
+            'media_type'  => 'image/png',
+            'total_bytes' => filesize(__FILE__),
+        ])->shouldBeCalled();
+
+        $response = $this->prophesize(Response::class);
+        $response->getBody()->willReturn('{"media_id": "XXXX"}');
+        $response->getHeaders()->willReturn(null);
+        $response->isSuccess()->will(function () use ($media) {
+            $r = new ReflectionProperty($media, 'imageFilename');
+            $r->setAccessible(true);
+            $r->setValue($media, '  This File Does Not Exist  ');
+            return true;
+        });
+
+        $this->client->send()->will([$response, 'reveal']);
+
+        $this->expectException(Exception\MediaUploadException::class);
+        $this->expectExceptionMessage('Failed to open the file in the APPEND');
+        $media->upload($this->client->reveal());
+    }
+
+    public function testAppendUploadRaisesExceptionIfChunkUploadFails()
+    {
+        $media = new Media(__FILE__, 'image/png');
+
+        $this->client->setUri(Media::UPLOAD_BASE_URI)->shouldBeCalled();
+        $this->client->resetParameters()->shouldBeCalledTimes(2);
+        $this->client->setHeaders([
+            'Content-type' => 'application/x-www-form-urlencoded'
+        ])->shouldBeCalledTimes(2);
+        $this->client->setMethod('POST')->shouldBeCalledTimes(2);
+        $this->client->setParameterPost([
+            'command'     => 'INIT',
+            'media_type'  => 'image/png',
+            'total_bytes' => filesize(__FILE__),
+        ])->shouldBeCalled();
+
+        $this->client->setParameterPost(Argument::that(function ($arg) use (&$commands) {
+            TestCase::assertInternalType('array', $arg);
+            TestCase::assertArrayHasKey('command', $arg);
+            TestCase::assertTrue(in_array($arg['command'], ['INIT', 'APPEND']));
+            return true;
+        }))->shouldBeCalledTimes(2);
+
+        $initResponse = $this->prophesize(Response::class);
+        $initResponse->getBody()->willReturn('{"media_id": "XXXX"}');
+        $initResponse->getHeaders()->willReturn(null);
+        $initResponse->isSuccess()->willReturn(true);
+
+        $appendResponse = $this->prophesize(Response::class);
+        $appendResponse->getBody()->willReturn('{}');
+        $appendResponse->getHeaders()->willReturn(null);
+        $appendResponse->isSuccess()->willReturn(false);
+        $appendResponse->getStatusCode()->willReturn(400);
+        $appendResponse->getReasonPhrase()->willReturn('Borked');
+
+        $this->client->send()->willReturn(
+            $initResponse->reveal(),
+            $appendResponse->reveal()
+        );
+
+        $this->expectException(Exception\MediaUploadException::class);
+        $this->expectExceptionMessage('Failed uploading segment');
+        $media->upload($this->client->reveal());
+    }
+
+    public function testReturnsFinalizeCommandResponseWhenInitializationAndAppendAreSuccessful()
+    {
+        $media = new Media(__FILE__, 'image/png');
+        $r = new ReflectionProperty($media, 'chunkSize');
+        $r->setAccessible(true);
+        $r->setValue($media, 4 * filesize(__FILE__));
+
+        $client = $this->client;
+        $client->setUri(Media::UPLOAD_BASE_URI)->shouldBeCalled();
+        $client->resetParameters()->shouldBeCalled();
+        $client->setHeaders([
+            'Content-type' => 'application/x-www-form-urlencoded'
+        ])->shouldBeCalledTimes(3);
+        $client->setMethod('POST')->shouldBeCalledTimes(3);
+
+        $commands = [];
+        $client->setParameterPost(Argument::that(function ($arg) use (&$commands) {
+            TestCase::assertInternalType('array', $arg);
+            TestCase::assertArrayHasKey('command', $arg);
+            $commands[] = $arg['command'];
+            return true;
+        }))->shouldBeCalledTimes(3);
+
+        $initResponse = $this->prophesize(Response::class);
+        $initResponse->getBody()->willReturn('{"media_id": "XXXX"}');
+        $initResponse->getHeaders()->willReturn(null);
+        $initResponse->isSuccess()->willReturn(true);
+
+        $appendResponse = $this->prophesize(Response::class);
+        $appendResponse->getBody()->willReturn('{}');
+        $appendResponse->getHeaders()->willReturn(null);
+        $appendResponse->isSuccess()->willReturn(true);
+
+        $finalizeResponse = $this->prophesize(Response::class);
+        $finalizeResponse->getBody()->willReturn('{}');
+        $finalizeResponse->getHeaders()->willReturn(null);
+
+        $client->send()->willReturn(
+            $initResponse->reveal(),
+            $appendResponse->reveal(),
+            $finalizeResponse->reveal()
+        );
+
+        $response = $media->upload($client->reveal());
+        $this->assertInstanceOf(TwitterResponse::class, $response);
+        $this->assertAttributeSame($finalizeResponse->reveal(), 'httpResponse', $response);
+        $this->assertEquals(['INIT', 'APPEND', 'FINALIZE'], $commands);
+    }
+}

--- a/tests/ZendService/Twitter/RateLimitTest.php
+++ b/tests/ZendService/Twitter/RateLimitTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/ZendService_Twitter for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/ZendService_Twitter/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendServiceTest\Twitter;
+
+use PHPUnit\Framework\TestCase;
+use Zend\Http\Header\HeaderInterface;
+use Zend\Http\Headers;
+use ZendService\Twitter\RateLimit;
+
+class RateLimitTest extends TestCase
+{
+    public function testInstantiatingWithNoArgumentLeavesAllPropertiesNull()
+    {
+        $rateLimit = new RateLimit();
+        $this->assertNull($rateLimit->limit);
+        $this->assertNull($rateLimit->remaining);
+        $this->assertNull($rateLimit->reset);
+    }
+
+    public function headersProvider()
+    {
+        return [
+            'limit-only'     => [5000, null, null],
+            'remaining-only' => [null, 271, null],
+            'reset-only'     => [null, null, 3600],
+            'all-values'     => [5000, 271, 3600],
+        ];
+    }
+
+    /**
+     * @dataProvider headersProvider
+     */
+    public function testConstructorUsesHeadersToSetProperties($limit, $remaining, $reset)
+    {
+        $phpunit = $this;
+        $headers = $this->prophesize(Headers::class);
+
+        if (! $limit) {
+            $headers->has('x-rate-limit-limit')->willReturn(false);
+            $limit = 0;
+        } else {
+            $headers->has('x-rate-limit-limit')->willReturn(true);
+            $headers->get('x-rate-limit-limit')->will(function () use ($limit, $phpunit) {
+                $header = $phpunit->prophesize(HeaderInterface::class);
+                $header->getFieldValue()->willReturn($limit);
+                return $header->reveal();
+            });
+        }
+
+        if (! $remaining) {
+            $headers->has('x-rate-limit-remaining')->willReturn(false);
+            $remaining = 0;
+        } else {
+            $headers->has('x-rate-limit-remaining')->willReturn(true);
+            $headers->get('x-rate-limit-remaining')->will(function () use ($remaining, $phpunit) {
+                $header = $phpunit->prophesize(HeaderInterface::class);
+                $header->getFieldValue()->willReturn($remaining);
+                return $header->reveal();
+            });
+        }
+
+        if (! $reset) {
+            $headers->has('x-rate-limit-reset')->willReturn(false);
+            $reset = 0;
+        } else {
+            $headers->has('x-rate-limit-reset')->willReturn(true);
+            $headers->get('x-rate-limit-reset')->will(function () use ($reset, $phpunit) {
+                $header = $phpunit->prophesize(HeaderInterface::class);
+                $header->getFieldValue()->willReturn($reset);
+                return $header->reveal();
+            });
+        }
+
+        $rateLimit = new RateLimit($headers->reveal());
+
+        $this->assertSame($limit, $rateLimit->limit);
+        $this->assertSame($remaining, $rateLimit->remaining);
+        $this->assertSame($reset, $rateLimit->reset);
+    }
+}

--- a/tests/ZendService/Twitter/ResponseTest.php
+++ b/tests/ZendService/Twitter/ResponseTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/ZendService_Twitter for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/ZendService_Twitter/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendServiceTest\Twitter;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use Zend\Http\Header\HeaderInterface;
+use Zend\Http\Headers;
+use Zend\Http\Response as HttpResponse;
+use ZendService\Twitter\RateLimit;
+use ZendService\Twitter\Response;
+
+class ResponseTest extends TestCase
+{
+    public function testPopulateAddsRateLimitBasedOnHttpResponseHeaders()
+    {
+        $phpunit = $this;
+
+        $headers = $this->prophesize(Headers::class);
+        $headers->has('x-rate-limit-limit')->willReturn(true);
+        $headers->get('x-rate-limit-limit')->will(function () use ($phpunit) {
+            $header = $phpunit->prophesize(HeaderInterface::class);
+            $header->getFieldValue()->willReturn(3600);
+            return $header->reveal();
+        });
+        $headers->has('x-rate-limit-remaining')->willReturn(true);
+        $headers->get('x-rate-limit-remaining')->will(function () use ($phpunit) {
+            $header = $phpunit->prophesize(HeaderInterface::class);
+            $header->getFieldValue()->willReturn(237);
+            return $header->reveal();
+        });
+        $headers->has('x-rate-limit-reset')->willReturn(true);
+        $headers->get('x-rate-limit-reset')->will(function () use ($phpunit) {
+            $header = $phpunit->prophesize(HeaderInterface::class);
+            $header->getFieldValue()->willReturn(4200);
+            return $header->reveal();
+        });
+
+        $httpResponse = $this->prophesize(HttpResponse::class);
+        $httpResponse->getHeaders()->will([$headers, 'reveal']);
+        $httpResponse->getBody()->willReturn('{}');
+
+        $response = new Response($httpResponse->reveal());
+        $this->assertAttributeInstanceOf(RateLimit::class, 'rateLimit', $response);
+
+        $r = new ReflectionProperty($response, 'rateLimit');
+        $r->setAccessible(true);
+        $rateLimit = $r->getValue($response);
+
+        $this->assertSame(3600, $rateLimit->limit);
+        $this->assertSame(237, $rateLimit->remaining);
+        $this->assertSame(4200, $rateLimit->reset);
+    }
+}

--- a/tests/ZendService/Twitter/TwitterTest.php
+++ b/tests/ZendService/Twitter/TwitterTest.php
@@ -10,7 +10,7 @@
 
 namespace ZendTest\Twitter;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Zend\Http;
 use ZendOAuth\Client as OAuthClient;
@@ -194,7 +194,7 @@ class TwitterTest extends TestCase
 
     public function testAuthorisationFailureWithUsernameAndNoAccessToken()
     {
-        $this->setExpectedException(Twitter\Exception\ExceptionInterface::class);
+        $this->expectException(Twitter\Exception\ExceptionInterface::class);
         $twitter = new Twitter\Twitter(['username' => 'me']);
         $twitter->statusesPublicTimeline();
     }
@@ -237,7 +237,7 @@ class TwitterTest extends TestCase
      */
     public function testRetrievingStatusesWithInvalidScreenNameCharacterThrowsInvalidScreenNameException()
     {
-        $this->setExpectedException(Twitter\Exception\ExceptionInterface::class);
+        $this->expectException(Twitter\Exception\ExceptionInterface::class);
         $twitter = new Twitter\Twitter();
         $twitter->statuses->userTimeline(['screen_name' => 'abc.def']);
     }
@@ -247,7 +247,7 @@ class TwitterTest extends TestCase
      */
     public function testRetrievingStatusesWithInvalidScreenNameLengthThrowsInvalidScreenNameException()
     {
-        $this->setExpectedException(Twitter\Exception\ExceptionInterface::class);
+        $this->expectException(Twitter\Exception\ExceptionInterface::class);
         $twitter = new Twitter\Twitter();
         $twitter->statuses->userTimeline(['screen_name' => 'abcdef_abc123_abc123x']);
     }
@@ -291,14 +291,14 @@ class TwitterTest extends TestCase
 
     public function testOverloadingGetShouldthrowExceptionWithInvalidMethodType()
     {
-        $this->setExpectedException(Twitter\Exception\ExceptionInterface::class);
+        $this->expectException(Twitter\Exception\ExceptionInterface::class);
         $twitter = new Twitter\Twitter;
         $return = $twitter->foo;
     }
 
     public function testOverloadingGetShouldthrowExceptionWithInvalidFunction()
     {
-        $this->setExpectedException(Twitter\Exception\ExceptionInterface::class);
+        $this->expectException(Twitter\Exception\ExceptionInterface::class);
         $twitter = new Twitter\Twitter;
         $return = $twitter->foo();
     }
@@ -317,7 +317,7 @@ class TwitterTest extends TestCase
 
     public function testMethodProxyingThrowExceptionsWithInvalidMethods()
     {
-        $this->setExpectedException(Twitter\Exception\ExceptionInterface::class);
+        $this->expectException(Twitter\Exception\ExceptionInterface::class);
         $twitter = new Twitter\Twitter;
         $twitter->statuses->foo();
     }
@@ -439,14 +439,14 @@ class TwitterTest extends TestCase
 
     public function testPostStatusUpdateToLongShouldThrowException()
     {
-        $this->setExpectedException(Twitter\Exception\ExceptionInterface::class);
+        $this->expectException(Twitter\Exception\ExceptionInterface::class);
         $twitter = new Twitter\Twitter;
         $twitter->statuses->update('Test Message - ' . str_repeat(' Hello ', 140));
     }
 
     public function testPostStatusUpdateEmptyShouldThrowException()
     {
-        $this->setExpectedException(Twitter\Exception\ExceptionInterface::class);
+        $this->expectException(Twitter\Exception\ExceptionInterface::class);
         $twitter = new Twitter\Twitter;
         $twitter->statuses->update('');
     }

--- a/tests/ZendService/Twitter/VideoTest.php
+++ b/tests/ZendService/Twitter/VideoTest.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/ZendService_Twitter for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/ZendService_Twitter/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendServiceTest\Twitter;
+
+use PHPUnit\Framework\TestCase;
+use ZendService\Twitter\Video;
+
+class VideoTest extends TestCase
+{
+    public function testCanBeInstantiatedWithNoMediaTypeAndUsesSaneDefaults()
+    {
+        $video = new Video(__FILE__);
+        $this->assertAttributeEquals(__FILE__, 'imageFilename', $video);
+        $this->assertAttributeEquals('video/mp4', 'mediaType', $video);
+    }
+
+    public function testCanBeInstantiatedWithFilenameAndMediaType()
+    {
+        $video = new Video(__FILE__, 'text/plain');
+        $this->assertAttributeEquals(__FILE__, 'imageFilename', $video);
+        $this->assertAttributeEquals('text/plain', 'mediaType', $video);
+    }
+}


### PR DESCRIPTION
This patch incorporates #34 in order to provide testing. A number of minor refactors were performed to simplify usage, provide consistency, and provide testability.

Additionally, per feedback from @Ocramius, this patch updates the component to target PHP 7.1+, allowing the code to provide scalar type hints and return type hints, which allows far simpler error handling and reduced maintenance overhead.