### PR TITLE
Update the Direct Message text limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ matrix:
 
 before_install:
  - cp tests/TestConfiguration.php.travis tests/TestConfiguration.php
- - if [[ $TRAVIS_PHP_VERSION =~ ^7.1 ]];then phpenv config-rm xdebug.ini ; fi
  - travis_retry composer self-update
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,9 @@ matrix:
     - php: 7.2
 
 before_install:
-  - if [[ $TRAVIS_PHP_VERSION =~ ^7.1 ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
-  - cp tests/TestConfiguration.php.travis tests/TestConfiguration.php
-  - travis_retry composer self-update
+ - cp tests/TestConfiguration.php.travis tests/TestConfiguration.php
+ - if [[ $TRAVIS_PHP_VERSION =~ ^7.1 ]];then phpenv config-rm xdebug.ini ; fi
+ - travis_retry composer self-update
 
 install:
   - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs

--- a/library/ZendService/Twitter/Image.php
+++ b/library/ZendService/Twitter/Image.php
@@ -14,9 +14,6 @@ namespace ZendService\Twitter;
  */
 class Image extends Media
 {
-    /**
-     * @param $imageUrl
-     */
     public function __construct(string $imageUrl, string $mediaType = 'image/jpeg')
     {
         parent::__construct($imageUrl, $mediaType);

--- a/library/ZendService/Twitter/Twitter.php
+++ b/library/ZendService/Twitter/Twitter.php
@@ -479,9 +479,15 @@ class Twitter
         $path = 'direct_messages/new';
 
         $len = iconv_strlen($text, 'UTF-8');
-        if (0 == $len) {
+        if (0 === $len) {
             throw new Exception\InvalidArgumentException(
                 'Direct message must contain at least one character'
+            );
+        }
+
+        if (10000 < $len) {
+            throw new Exception\InvalidArgumentException(
+                'Direct message must be no more than 10000 characters'
             );
         }
 


### PR DESCRIPTION
PRs #34 and #39 remove the direct message limit when creating a new direct message to a user. However, per https://dev.twitter.com/rest/reference/post/direct_messages/events/new, DM text can be no more than 10k characters in length.

This patch is based on #39, and will be rebased once that PR is merged. It modifies the limit, raising a separate exception if the number of characters is `>` 10000. Tests have been added for that method to verify the upper and lower bounds of message length.