### PR TITLE
Provide media attachment support for direct messages

### DIFF
--- a/library/ZendService/Twitter/Image.php
+++ b/library/ZendService/Twitter/Image.php
@@ -14,8 +14,12 @@ namespace ZendService\Twitter;
  */
 class Image extends Media
 {
-    public function __construct(string $imageUrl, string $mediaType = 'image/jpeg')
-    {
-        parent::__construct($imageUrl, $mediaType);
+    public function __construct(
+        string $imageUrl,
+        string $mediaType = 'image/jpeg',
+        bool $forDirectMessage = false,
+        bool $shared = false
+    ) {
+        parent::__construct($imageUrl, $mediaType, $forDirectMessage, $shared);
     }
 }

--- a/library/ZendService/Twitter/Video.php
+++ b/library/ZendService/Twitter/Video.php
@@ -14,8 +14,12 @@ namespace ZendService\Twitter;
  */
 class Video extends Media
 {
-    public function __construct(string $imageUrl, string $mediaType = 'video/mp4')
-    {
-        parent::__construct($imageUrl, $mediaType);
+    public function __construct(
+        string $imageUrl,
+        string $mediaType = 'video/mp4',
+        bool $forDirectMessage = false,
+        bool $shared = false
+    ) {
+        parent::__construct($imageUrl, $mediaType, $forDirectMessage, $shared);
     }
 }

--- a/tests/ZendService/Twitter/_files/direct_messages.events.new.json
+++ b/tests/ZendService/Twitter/_files/direct_messages.events.new.json
@@ -1,0 +1,24 @@
+{
+  "event": {
+    "type": "message_create",
+    "id": "1234858585",
+    "created_timestamp": "1392078023507",
+    "message_create": {
+      "target": {
+        "recipient_id": "1"
+      },
+      "sender_id": "2",
+      "message_data": {
+        "text": "Message",
+        "entities": {
+          "hashtags": [],
+          "symbols": [],
+          "urls": [],
+          "user_mentions": []
+        },
+        "quick_reply": {},
+        "attachment": {}
+      }
+    }
+  }
+}

--- a/tests/ZendService/Twitter/_files/direct_messages.events.new.media.json
+++ b/tests/ZendService/Twitter/_files/direct_messages.events.new.media.json
@@ -1,0 +1,29 @@
+{
+  "event": {
+    "type": "message_create",
+    "id": "1234858585",
+    "created_timestamp": "1392078023507",
+    "message_create": {
+      "target": {
+        "recipient_id": "1"
+      },
+      "sender_id": "2",
+      "message_data": {
+        "text": "Message",
+        "entities": {
+          "hashtags": [],
+          "symbols": [],
+          "urls": [],
+          "user_mentions": []
+        },
+        "quick_reply": {},
+        "attachment": {
+          "type": "media",
+          "media": {
+              "id": "XXXX"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Per the [Twitter API documentation](https://dev.twitter.com/rest/reference/post/direct_messages/events/new), Direct Messages now have a new REST endpoint that allows for more features, such as media attachments.

This patch builds on #34, #39, and #41, and does the following:

- Adds support for specifying a media upload as being for a direct message; optionally, if flagged as such, the user may also indicate the media is intended to be shared in other direct messages.
- Adds support for the `direct_messages/events/new` endpoint via a new method `directMessagesEventsNew()`; specifically:
  - If a Twitter _screen name_ is provided instead of an identifier, it will perform a lookup for the user's identifier.
  - If a `media_id` is provided in the new `$extraParams` argument, it will be used as a message attachment.

Additionally, the `directMessagesNew()` method was modified to proxy to the new method, as the `direct_messages/new` endpoint is considered deprecated.