### PR TITLE
Allow returning media entites via `statusesShow()`

### DIFF
--- a/library/ZendService/Twitter/Twitter.php
+++ b/library/ZendService/Twitter/Twitter.php
@@ -991,27 +991,18 @@ class Twitter
         $params = [];
         foreach ($options as $key => $value) {
             switch (strtolower($key)) {
+                case 'tweet_mode':
+                    unset($params[$key]);
+                    $params['tweet_mode'] = 'extended';
+                    break;
                 case 'include_entities':
-                    $params['include_entities'] = (bool) $value;
+                    $params[strtolower($key)] = (bool) $value;
                     break;
                 case 'trim_user':
-                    if (in_array($value, [true, 'true', 't', 1, '1'])) {
-                        $value = true;
-                    } else {
-                        $value = false;
-                    }
-                    $params['trim_user'] = $value;
+                    $params[strtolower($key)] = (bool) $value;
                     break;
                 case 'include_my_retweet':
-                    if (in_array($value, [true, 'true', 't', 1, '1'])) {
-                        $value = true;
-                    } else {
-                        $value = false;
-                    }
-                    $params['include_my_retweet'] = $value;
-                    break;
-                case 'tweet_mode':
-                    $params['tweet_mode'] = 'extended';
+                    $params[strtolower($key)] = (bool) $value;
                     break;
                 default:
                     break;

--- a/tests/ZendService/Twitter/TwitterTest.php
+++ b/tests/ZendService/Twitter/TwitterTest.php
@@ -1002,4 +1002,30 @@ class TwitterTest extends TestCase
         $response = $twitter->directMessages->new('1', 'Message', ['media_id' => 'XXXX']);
         $this->assertInstanceOf(TwitterResponse::class, $response);
     }
+
+    public function testStatusesShowWillPassAdditionalOptionsWhenPresent()
+    {
+        $twitter = new Twitter\Twitter();
+        $twitter->setHttpClient($this->stubOAuthClient(
+            'statuses/show/12345.json',
+            Http\Request::METHOD_GET,
+            'statuses.show.json',
+            [
+                'tweet_mode' => 'extended',
+                'include_entities' => true,
+                'trim_user' => true,
+                'include_my_retweet' => true,
+            ]
+        ));
+
+        $finalResponse = $twitter->statuses->show(12345, [
+            'tweet_mode' => true,
+            'include_entities' => true,
+            'trim_user' => true,
+            'include_my_retweet' => true,
+            'should_not_be_included' => true,
+        ]);
+
+        $this->assertInstanceOf(TwitterResponse::class, $finalResponse);
+    }
 }


### PR DESCRIPTION
This pull request replaces #37, incorporating feedback previously given, and adding tests.