### PR TITLE
Twitter API v1.1 doesn't use body content only

### DIFF
--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -1502,15 +1502,10 @@ class Twitter
      */
     protected function performPost(string $method, $data, Http\Client $client) : Http\Response
     {
-        if (is_array($data) || is_object($data)) {
-            $data = json_encode($data, $this->jsonFlags);
-        }
-
-        if (! empty($data)) {
+        if (is_string($data)) {
             $client->setRawBody($data);
-            $client->getRequest()
-                ->getHeaders()
-                ->addHeaderLine('Content-Type', 'application/json');
+        } elseif (is_array($data) || is_object($data)) {
+            $client->setParameterPost((array) $data);
         }
 
         $client->setMethod($method);


### PR DESCRIPTION
Example : https://api.twitter.com/1.1/statuses/update.json is called like this : 
POST https://api.twitter.com/1.1/statuses/update.json?status=Maybe%20he%27ll%20finally%20find%20his%20keys.%20%23peterfalk

Body content is not used by the Twitter API and returns "Missing required parameter: status"

see [documentation](https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-statuses-update)