### PR TITLE
Fix the direct message payload to conform to API expectations

### DIFF
--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -616,7 +616,7 @@ class Twitter
             ];
         }
 
-        return $this->post($path, $params);
+        return $this->post($path, ['event' => $params]);
     }
 
     /**

--- a/test/TwitterTest.php
+++ b/test/TwitterTest.php
@@ -848,13 +848,15 @@ class TwitterTest extends TestCase
             Http\Request::METHOD_POST,
             'direct_messages.events.new.json',
             [
-                'type' => 'message_create',
-                'message_create' => [
-                    'target' => [
-                        'recipient_id' => '1',
-                    ],
-                    'message_data' => [
-                        'text' => 'Message',
+                'event' => [
+                    'type' => 'message_create',
+                    'message_create' => [
+                        'target' => [
+                            'recipient_id' => '1',
+                        ],
+                        'message_data' => [
+                            'text' => 'Message',
+                        ],
                     ],
                 ],
             ]
@@ -889,13 +891,15 @@ class TwitterTest extends TestCase
         $client->getRequest()->will([$request, 'reveal']);
 
         $data = [
-            'type' => 'message_create',
-            'message_create' => [
-                'target' => [
-                    'recipient_id' => '1',
-                ],
-                'message_data' => [
-                    'text' => 'Message',
+            'event' => [
+                'type' => 'message_create',
+                'message_create' => [
+                    'target' => [
+                        'recipient_id' => '1',
+                    ],
+                    'message_data' => [
+                        'text' => 'Message',
+                    ],
                 ],
             ],
         ];
@@ -957,13 +961,15 @@ class TwitterTest extends TestCase
             Http\Request::METHOD_POST,
             'direct_messages.events.new.json',
             [
-                'type' => 'message_create',
-                'message_create' => [
-                    'target' => [
-                        'recipient_id' => '1',
-                    ],
-                    'message_data' => [
-                        'text' => 'Message',
+                'event' => [
+                    'type' => 'message_create',
+                    'message_create' => [
+                        'target' => [
+                            'recipient_id' => '1',
+                        ],
+                        'message_data' => [
+                            'text' => 'Message',
+                        ],
                     ],
                 ],
             ]
@@ -980,17 +986,19 @@ class TwitterTest extends TestCase
             Http\Request::METHOD_POST,
             'direct_messages.events.new.media.json',
             [
-                'type' => 'message_create',
-                'message_create' => [
-                    'target' => [
-                        'recipient_id' => '1',
-                    ],
-                    'message_data' => [
-                        'text' => 'Message',
-                        'attachment' => [
-                            'type' => 'media',
-                            'media' => [
-                                'id' => 'XXXX',
+                'event' => [
+                    'type' => 'message_create',
+                    'message_create' => [
+                        'target' => [
+                            'recipient_id' => '1',
+                        ],
+                        'message_data' => [
+                            'text' => 'Message',
+                            'attachment' => [
+                                'type' => 'media',
+                                'media' => [
+                                    'id' => 'XXXX',
+                                ],
                             ],
                         ],
                     ],


### PR DESCRIPTION
Per #50, the direct message payload is an _events_ payload, and needs to be wrapped in an `event` object when submitted.