### PR TITLE
Send (most) payloads as form-urlencoded data

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -71,3 +71,9 @@ The following is a list of Twitter API methods not yet implemented:
 - users/suggestions
 - users/suggestions/:slug
 - users/suggestions/:slug/members
+
+## Fixes/functionality updates
+
+- Use `Normalizer` class to get normalized string, and then use that to count
+  number of characters for purpose of string lengths.
+- Update allowed status length to 280 characters.

--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -1272,7 +1272,20 @@ class Twitter
         if ($inReplyToStatusId) {
             $params['in_reply_to_status_id'] = $inReplyToStatusId;
         }
-        return $this->post($path, $params);
+
+        // For some reason, this endpoint DOES NOT accept JSON, but only form
+        // encoded parameters. As such, we do not call `post()` here, but instead
+        // interact directly with the HTTP client.
+        // @see https://github.com/zendframework/ZendService_Twitter/issues/48
+        $httpClient = $this->getHttpClient();
+        $this->init($path, $httpClient);
+        $httpClient->setMethod('POST');
+        $httpClient
+            ->getRequest()
+            ->getHeaders()
+            ->addHeaderLine('Content-Type', 'application/x-www-form-urlencoded');
+        $httpClient->setParameterPost($params);
+        return new Response($httpClient->send());
     }
 
     /**

--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -33,6 +33,15 @@ class Twitter
     const OAUTH_BASE_URI = 'https://api.twitter.com/oauth';
 
     /**
+     * Paths that use JSON payloads (vs form-encoded)
+     */
+    const PATHS_JSON_PAYLOAD = [
+        'direct_messages/events/new',
+        'direct_messages/welcome_messages/new',
+        'direct_messages/welcome_messages/rules/new',
+    ];
+
+    /**
      * 246 is the current limit for a status message, 140 characters are displayed
      * initially, with the remainder linked from the web UI or client. The limit is
      * applied to a html encoded UTF-8 string (i.e. entities are counted in the limit
@@ -402,7 +411,12 @@ class Twitter
     {
         $client = $this->getHttpClient();
         $this->init($path, $client);
-        $response = $this->performPost(Http\Request::METHOD_POST, $data, $client);
+        $response = $this->performPost(
+            Http\Request::METHOD_POST,
+            $data,
+            $client,
+            in_array($path, self::PATHS_JSON_PAYLOAD, true)
+        );
         return new Response($response);
     }
 
@@ -1273,19 +1287,7 @@ class Twitter
             $params['in_reply_to_status_id'] = $inReplyToStatusId;
         }
 
-        // For some reason, this endpoint DOES NOT accept JSON, but only form
-        // encoded parameters. As such, we do not call `post()` here, but instead
-        // interact directly with the HTTP client.
-        // @see https://github.com/zendframework/ZendService_Twitter/issues/48
-        $httpClient = $this->getHttpClient();
-        $this->init($path, $httpClient);
-        $httpClient->setMethod('POST');
-        $httpClient
-            ->getRequest()
-            ->getHeaders()
-            ->addHeaderLine('Content-Type', 'application/x-www-form-urlencoded');
-        $httpClient->setParameterPost($params);
-        return new Response($httpClient->send());
+        return $this->post($path, $params);
     }
 
     /**
@@ -1512,21 +1514,17 @@ class Twitter
      * is JSON-encoded before being passed to the request body.
      *
      * @param null|string|array|\stdClass $data Raw data to send
+     * @param bool $asJson Whether or not the data should be submitted as JSON
+     *     (vs form urlencoded, which is the default)
      */
-    protected function performPost(string $method, $data, Http\Client $client) : Http\Response
+    protected function performPost(string $method, $data, Http\Client $client, bool $asJson) : Http\Response
     {
-        if (is_array($data) || is_object($data)) {
-            $data = json_encode($data, $this->jsonFlags);
-        }
-
-        if (! empty($data)) {
-            $client->setRawBody($data);
-            $client->getRequest()
-                ->getHeaders()
-                ->addHeaderLine('Content-Type', 'application/json');
-        }
-
         $client->setMethod($method);
+
+        $asJson
+            ? $this->prepareJsonPayloadForClient($client, $data)
+            : $this->prepareFormPayloadForClient($client, $data);
+
         return $client->send();
     }
 
@@ -1641,5 +1639,37 @@ class Twitter
         array_walk($ids, Closure::fromCallable([$this, 'validateScreenName']));
         $params['screen_name'] = implode(',', $ids);
         return $params;
+    }
+
+    /**
+     * Prepare a JSON payload for the HTTP client.
+     */
+    private function prepareJsonPayloadForClient(Http\Client $client, $data)
+    {
+        if (is_array($data) || is_object($data)) {
+            $data = json_encode($data, $this->jsonFlags);
+        }
+
+        if (empty($data) || ! is_string($data)) {
+            return;
+        }
+
+        $client->getRequest()
+            ->getHeaders()
+            ->addHeaderLine('Content-Type', 'application/json');
+
+        $client->setRawBody($data);
+    }
+
+    /**
+     * Prepare a form-url-encoded payload for the HTTP client.
+     */
+    private function prepareFormPayloadForClient(Http\Client $client, $data)
+    {
+        if (! is_array($data)) {
+            return;
+        }
+
+        $client->setParameterPost($data);
     }
 }


### PR DESCRIPTION
As it turns out, while the expected content-type is still application/json (though in practice it doesn't matter what you send), the actual expected _contents_ are supposed to be application/x-www-form-urlencoded regardless, except in a few cases (direct messages and media uploads).

This patch modifies the `post()` and `performPost()` methods slightly: the former checks to see if the provided `$path` is in a known whitelist for JSON payloads, and passes the result on to `performPost()`. That method then varies how the payload is created and injected into the request accordingly.

Fixes #48.