### PR TITLE
Allow 280 characters for status updates

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -71,9 +71,3 @@ The following is a list of Twitter API methods not yet implemented:
 - users/suggestions
 - users/suggestions/:slug
 - users/suggestions/:slug/members
-
-## Fixes/functionality updates
-
-- Use `Normalizer` class to get normalized string, and then use that to count
-  number of characters for purpose of string lengths.
-- Update allowed status length to 280 characters.

--- a/test/TwitterTest.php
+++ b/test/TwitterTest.php
@@ -485,6 +485,20 @@ class TwitterTest extends TestCase
         $twitter->statuses->update('Test Message - ' . str_repeat(' Hello ', 140));
     }
 
+    public function testStatusUpdateShouldAllow280CharactersOfUTF8Encoding()
+    {
+        $message = str_repeat('é', 280);
+        $twitter = new Twitter\Twitter;
+        $twitter->setHttpClient($this->stubOAuthClient(
+            'statuses/update.json',
+            Http\Request::METHOD_POST,
+            'statuses.update.json',
+            ['status' => $message]
+        ));
+        $response = $twitter->statuses->update($message);
+        $this->assertInstanceOf(TwitterResponse::class, $response);
+    }
+
     public function testPostStatusUpdateEmptyShouldThrowException()
     {
         $this->expectException(Twitter\Exception\ExceptionInterface::class);


### PR DESCRIPTION
Updates `STATUS_MAX_CHARACTERS` to 280, and updates all character counting operations to use the construct `strlen(utf8_decode($string))`, which provides an accurate count for purposes of the Twitter API (which treats multi-byte characters as single characters).