### PR TITLE
Added param tweet_mode=extended for timelines too

### DIFF
--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -1114,6 +1114,10 @@ class Twitter
                 case 'max_id':
                     $params['max_id'] = $this->validInteger($value);
                     break;
+                case 'tweet_mode':
+                    unset($params[$key]);
+                    $params['tweet_mode'] = 'extended';
+                    break;
                 case 'trim_user':
                     if (in_array($value, [true, 'true', 't', 1, '1'])) {
                         $value = true;
@@ -1168,6 +1172,10 @@ class Twitter
                     break;
                 case 'max_id':
                     $params['max_id'] = $this->validInteger($value);
+                    break;
+                case 'tweet_mode':
+                    unset($params[$key]);
+                    $params['tweet_mode'] = 'extended';
                     break;
                 case 'trim_user':
                     if (in_array($value, [true, 'true', 't', 1, '1'])) {
@@ -1333,6 +1341,10 @@ class Twitter
                     break;
                 case 'max_id':
                     $params['max_id'] = $this->validInteger($value);
+                    break;
+                case 'tweet_mode':
+                    unset($params[$key]);
+                    $params['tweet_mode'] = 'extended';
                     break;
                 case 'trim_user':
                     if (in_array($value, [true, 'true', 't', 1, '1'])) {

--- a/test/TwitterTest.php
+++ b/test/TwitterTest.php
@@ -309,6 +309,7 @@ class TwitterTest extends TestCase
                 'since_id' => '10000',
                 'max_id' => '20000',
                 'screen_name' => 'twitter',
+                'tweet_mode' => 'extended',
             ]
         ));
         $twitter->statuses->userTimeline([
@@ -319,7 +320,8 @@ class TwitterTest extends TestCase
             'user_id' => '783214',
             'since_id' => '10000',
             'max_id' => '20000',
-            'screen_name' => 'twitter'
+            'screen_name' => 'twitter',
+            'tweet_mode' => 'extended',
         ]);
     }
 
@@ -443,6 +445,19 @@ class TwitterTest extends TestCase
             ['count' => 3]
         ));
         $response = $twitter->statuses->homeTimeline(['count' => 3]);
+        $this->assertInstanceOf(TwitterResponse::class, $response);
+    }
+
+    public function testHomeTimelineWithExtendedModeReturnsResults()
+    {
+        $twitter = new Twitter\Twitter;
+        $twitter->setHttpClient($this->stubOAuthClient(
+            'statuses/home_timeline.json',
+            Http\Request::METHOD_GET,
+            'statuses.home_timeline.page.json',
+            ['tweet_mode' => 'extended']
+        ));
+        $response = $twitter->statuses->homeTimeline(['tweet_mode' => 'extended']);
         $this->assertInstanceOf(TwitterResponse::class, $response);
     }
 
@@ -610,6 +625,19 @@ class TwitterTest extends TestCase
             []
         ));
         $response = $twitter->statuses->mentionsTimeline();
+        $this->assertInstanceOf(TwitterResponse::class, $response);
+    }
+
+    public function testMentionsTimelineWithExtendedModeReturnsResults()
+    {
+        $twitter = new Twitter\Twitter;
+        $twitter->setHttpClient($this->stubOAuthClient(
+            'statuses/mentions_timeline.json',
+            Http\Request::METHOD_GET,
+            'statuses.mentions_timeline.json',
+            ['tweet_mode' => 'extended']
+        ));
+        $response = $twitter->statuses->mentionsTimeline(['tweet_mode' => 'extended']);
         $this->assertInstanceOf(TwitterResponse::class, $response);
     }
 


### PR DESCRIPTION
As of Sept 2017 Twitter allows tweet_mode=extended for various endpoints:
https://developer.twitter.com/en/docs/tweets/tweet-updates

That's why I added the parameter to the timeline endpoints :)
